### PR TITLE
fix serde for Policy BigInt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,7 @@ dependencies = [
  "itertools",
  "log",
  "multihash",
+ "num",
  "num-derive",
  "num-traits",
  "paste",
@@ -1102,6 +1103,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1111,6 +1113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1155,6 +1158,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/runtime_v9/Cargo.toml
+++ b/runtime_v9/Cargo.toml
@@ -22,6 +22,7 @@ getrandom           = { workspace = true }
 itertools           = { workspace = true }
 log                 = { workspace = true }
 multihash           = { workspace = true }
+num                 = { workspace = true, features = ["serde"] }
 num-derive          = { workspace = true }
 num-traits          = { workspace = true }
 paste               = { workspace = true }

--- a/runtime_v9/src/runtime/policy.rs
+++ b/runtime_v9/src/runtime/policy.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::sector::{RegisteredPoStProof, RegisteredSealProof, StoragePower};
 use num_traits::FromPrimitive;
@@ -137,7 +136,6 @@ pub struct Policy {
 
     // --- verifreg policy
     /// Minimum verified deal size
-    #[serde(with = "bigint_ser")]
     pub minimum_verified_allocation_size: StoragePower,
     /// Minimum term for a verified data allocation (epochs)
     pub minimum_verified_allocation_term: i64,
@@ -167,7 +165,6 @@ pub struct Policy {
 
     // --- power ---
     /// Minimum miner consensus power
-    #[serde(with = "bigint_ser")]
     pub minimum_consensus_power: StoragePower,
 }
 


### PR DESCRIPTION
Using a BigInt serializer from the `num` feature does work; however, it's not very pretty for huge numbers. E.g., `32 << 30` shows in TOML as `minimum_consensus_power = [1, [0, 2560]]`. On the other side it's alright for most cases like `1 << 20` `minimum_verified_allocation_size = [1, [1048576]]`.

Given that we seldom change those parameters, I propose we use a no-code solution.

Closes https://github.com/ChainSafe/fil-actor-states/issues/2