### PR TITLE
Shashank/add new v10 actors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,6 +1296,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actor_eam_v10"
+version = "10.0.0"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_evm_shared",
+ "fil_actors_runtime_v10",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.2.3",
+ "fvm_shared 2.0.0",
+ "log",
+ "multihash 0.16.3",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "serde_tuple",
+]
+
+[[package]]
+name = "fil_actor_evm_v10"
+version = "10.0.0"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_evm_shared",
+ "fil_actors_runtime_v10",
+ "frc42_dispatch",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 2.0.0",
+ "hex",
+ "hex-literal",
+ "log",
+ "multihash 0.16.3",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "serde_tuple",
+ "substrate-bn",
+]
+
+[[package]]
 name = "fil_actor_init_v10"
 version = "10.0.0-alpha.1"
 dependencies = [
@@ -1830,6 +1872,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actors_evm_shared"
+version = "10.0.0"
+dependencies = [
+ "fil_actors_runtime_v10",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0",
+ "hex",
+ "serde",
+ "uint",
+]
+
+[[package]]
 name = "fil_actors_runtime_v10"
 version = "10.0.0-alpha.1"
 dependencies = [
@@ -2002,7 +2056,7 @@ version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
- "spin",
+ "spin 0.9.5",
 ]
 
 [[package]]
@@ -2643,6 +2697,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,6 +2838,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "libc"
@@ -3847,6 +3910,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4124,6 +4193,12 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
@@ -4280,6 +4355,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.5",
+ "rustc-hex",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4400,6 +4488,18 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,7 +1202,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1215,7 +1215,7 @@ dependencies = [
  "fil_actors_runtime_v8",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1230,7 +1230,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1243,7 +1243,7 @@ dependencies = [
  "fil_actors_runtime_v10",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1256,7 +1256,7 @@ dependencies = [
  "fil_actors_runtime_v8",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1269,7 +1269,27 @@ dependencies = [
  "fil_actors_runtime_v9",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "fil_actor_datacap_v10"
+version = "10.0.0"
+dependencies = [
+ "cid",
+ "fil_actors_runtime_v10",
+ "frc42_dispatch",
+ "frc46_token",
+ "fvm_actor_utils 4.0.2",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.2.3",
+ "fvm_ipld_hamt 0.6.1",
+ "fvm_shared 2.0.0",
+ "lazy_static",
+ "log",
  "num-derive",
  "num-traits",
  "serde",
@@ -1286,7 +1306,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "log",
  "num-derive",
  "num-traits",
@@ -1303,7 +1323,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1319,7 +1339,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1364,7 +1384,7 @@ dependencies = [
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "libp2p",
  "num",
  "serde",
@@ -1383,7 +1403,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "integer-encoding",
  "itertools 0.10.5",
  "libipld-core 0.14.0",
@@ -1405,7 +1425,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "libipld-core 0.14.0",
  "num-derive",
  "num-traits",
@@ -1423,7 +1443,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "integer-encoding",
  "libipld-core 0.14.0",
  "num-derive",
@@ -1445,7 +1465,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -1469,7 +1489,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "itertools 0.10.5",
  "lazy_static",
  "libipld-core 0.14.0",
@@ -1491,7 +1511,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "itertools 0.10.5",
  "lazy_static",
  "libipld-core 0.14.0",
@@ -1512,7 +1532,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -1531,7 +1551,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "indexmap",
  "integer-encoding",
  "num-derive",
@@ -1550,7 +1570,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -1571,7 +1591,7 @@ dependencies = [
  "fvm_ipld_amt 0.5.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1586,7 +1606,7 @@ dependencies = [
  "fil_actors_runtime_v8",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1601,7 +1621,7 @@ dependencies = [
  "fil_actors_runtime_v9",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1618,7 +1638,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "integer-encoding",
  "lazy_static",
  "num-derive",
@@ -1636,7 +1656,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "integer-encoding",
  "lazy_static",
  "num-derive",
@@ -1654,7 +1674,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "integer-encoding",
  "lazy_static",
  "num-derive",
@@ -1669,7 +1689,7 @@ dependencies = [
  "fil_actors_runtime_v10",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "lazy_static",
  "num",
  "num-derive",
@@ -1685,7 +1705,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "lazy_static",
  "num",
  "num-derive",
@@ -1701,7 +1721,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "lazy_static",
  "num",
  "num-derive",
@@ -1717,7 +1737,7 @@ dependencies = [
  "cid",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1731,7 +1751,7 @@ dependencies = [
  "cid",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1745,7 +1765,7 @@ dependencies = [
  "cid",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "num-derive",
  "num-traits",
  "serde",
@@ -1760,11 +1780,11 @@ dependencies = [
  "fil_actors_runtime_v10",
  "frc42_dispatch",
  "frc46_token",
- "fvm_actor_utils",
+ "fvm_actor_utils 3.0.0",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "lazy_static",
  "log",
  "num-derive",
@@ -1782,7 +1802,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "lazy_static",
  "num-derive",
  "num-traits",
@@ -1801,7 +1821,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "lazy_static",
  "log",
  "num-derive",
@@ -1823,7 +1843,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "getrandom 0.2.8",
  "hex",
  "itertools 0.10.5",
@@ -1854,7 +1874,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "hex",
  "itertools 0.10.5",
  "lazy_static",
@@ -1883,7 +1903,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "hex",
  "itertools 0.10.5",
  "multihash 0.16.3",
@@ -2026,34 +2046,34 @@ dependencies = [
 
 [[package]]
 name = "frc42_dispatch"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a093747f6447d7528cf37b87b8ab9879c7417e960d2ea1ac523890eb3a924e2a"
+checksum = "d7bc80f65be319b625b0a09e86ba0793e3da8e4ab9030a801f0cdd00bbcb8e24"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
- "fvm_ipld_encoding 0.2.3",
- "fvm_sdk",
- "fvm_shared",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_sdk 3.0.0",
+ "fvm_shared 3.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "frc42_hasher"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf52e60a67e9ad15cd4909ef8c8e45ab3744015dbb603efd8dfbdbfc7ce95b7"
+checksum = "ab91345ff52851dfa6e3a253f08462e703a04c5c6458cecddbec9596519b9026"
 dependencies = [
- "fvm_sdk",
- "fvm_shared",
+ "fvm_sdk 3.0.0",
+ "fvm_shared 3.0.0",
  "thiserror",
 ]
 
 [[package]]
 name = "frc42_macros"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c343356c3652593452cc1cfe95535a915261342e2a4c13bb8388ca29b259a400"
+checksum = "b9e5a8b295ad4267907612c931b60f25ab7a74e540de41668cee96ce6af0ed3b"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
@@ -2071,13 +2091,13 @@ dependencies = [
  "anyhow",
  "cid",
  "frc42_dispatch",
- "fvm_actor_utils",
+ "fvm_actor_utils 3.0.0",
  "fvm_ipld_amt 0.4.2",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.5.1",
- "fvm_sdk",
- "fvm_shared",
+ "fvm_sdk 2.2.0",
+ "fvm_shared 2.0.0",
  "integer-encoding",
  "num-traits",
  "serde",
@@ -2216,7 +2236,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.5.1",
- "fvm_shared",
+ "fvm_shared 2.0.0",
  "lazy_static",
  "log",
  "multihash 0.16.3",
@@ -2254,8 +2274,27 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_sdk",
- "fvm_shared",
+ "fvm_sdk 2.2.0",
+ "fvm_shared 2.0.0",
+ "num-traits",
+ "serde",
+ "serde_tuple",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_actor_utils"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b37f347ddbb46adeba750a8bbc499d5b7f83610d977615b4bcd83b84081b8721"
+dependencies = [
+ "anyhow",
+ "cid",
+ "frc42_dispatch",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_sdk 3.0.0",
+ "fvm_shared 3.0.0",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -2288,7 +2327,7 @@ dependencies = [
  "anyhow",
  "cid",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.3.0",
+ "fvm_ipld_encoding 0.3.3",
  "itertools 0.10.5",
  "once_cell",
  "serde",
@@ -2301,7 +2340,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1950291f40d2d1047eb0a4568f7ef6d5b4973452dcef012dffb1957fe483ff7"
 dependencies = [
- "fvm_ipld_encoding 0.3.0",
+ "fvm_ipld_encoding 0.3.3",
  "serde",
  "thiserror",
  "unsigned-varint",
@@ -2338,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_encoding"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf531c59e7c9a4c9044a34d1b44c9d544fab1eb0ba50aaa18121fe698d4fec35"
+checksum = "f0816a2a6df4853de08a723d261110d56a121aa313bc570fe9d248f0a4bc5288"
 dependencies = [
  "anyhow",
  "cid",
@@ -2385,7 +2424,7 @@ dependencies = [
  "cid",
  "forest_hash_utils",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding 0.3.0",
+ "fvm_ipld_encoding 0.3.3",
  "libipld-core 0.14.0",
  "multihash 0.16.3",
  "once_cell",
@@ -2402,7 +2441,22 @@ checksum = "bb46d7b26e1609de1a3b7470cbd190d78f2d01fdf1b317f741bdd3ac8f59825e"
 dependencies = [
  "cid",
  "fvm_ipld_encoding 0.2.3",
- "fvm_shared",
+ "fvm_shared 2.0.0",
+ "lazy_static",
+ "log",
+ "num-traits",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_sdk"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fef17308967cceb1d22f05003d60adb0d5b9ba53e34ace4ae04701eb7e6af02"
+dependencies = [
+ "cid",
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 3.0.0",
  "lazy_static",
  "log",
  "num-traits",
@@ -2428,6 +2482,35 @@ dependencies = [
  "fvm_ipld_encoding 0.2.3",
  "lazy_static",
  "libsecp256k1",
+ "log",
+ "multihash 0.16.3",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "serde_repr",
+ "serde_tuple",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "fvm_shared"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99c06aa865e34198d9ca0da54e53e2fca14ae9ce5402f51b7c8e78175205861"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "blake2b_simd",
+ "byteorder",
+ "cid",
+ "data-encoding",
+ "data-encoding-macro",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.3.3",
+ "lazy_static",
  "log",
  "multihash 0.16.3",
  "num-bigint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,6 +1315,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fil_actor_ethaccount_v10"
+version = "10.0.0"
+dependencies = [
+ "fvm_ipld_encoding 0.3.3",
+ "fvm_shared 2.0.0",
+ "num-derive",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "fil_actor_evm_v10"
 version = "10.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "miner_v9",
   "miner_v10",
   "verifreg_v10",
+  "datacap_v10",
   "fil_actor_interface",
 ]
 resolver = "2"
@@ -79,6 +80,7 @@ serde_repr = "0.1.8"
 sha2 = "0.10.5"
 thiserror = "1.0"
 unsigned-varint = "0.7.1"
+fvm_actor_utils = "4.0.2"
 
 fil_actors_runtime_v8 = { path = "./runtime_v8" }
 fil_actors_runtime_v9 = { path = "./runtime_v9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
   "datacap_v10",
   "eam_v10",
   "evm_v10",
+  "ethaccount_v10",
   "fil_actor_interface",
 ]
 resolver = "2"
@@ -84,6 +85,7 @@ thiserror = "1.0"
 unsigned-varint = "0.7.1"
 fvm_actor_utils = "4.0.2"
 serde_tuple = "0.5"
+hex-literal = "0.3.4"
 
 fil_actors_runtime_v8 = { path = "./runtime_v8" }
 fil_actors_runtime_v9 = { path = "./runtime_v9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "verifreg_v10",
   "datacap_v10",
   "eam_v10",
+  "evm_v10",
   "fil_actor_interface",
 ]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
   "miner_v10",
   "verifreg_v10",
   "datacap_v10",
+  "eam_v10",
   "fil_actor_interface",
 ]
 resolver = "2"
@@ -81,6 +82,7 @@ sha2 = "0.10.5"
 thiserror = "1.0"
 unsigned-varint = "0.7.1"
 fvm_actor_utils = "4.0.2"
+serde_tuple = "0.5"
 
 fil_actors_runtime_v8 = { path = "./runtime_v8" }
 fil_actors_runtime_v9 = { path = "./runtime_v9" }

--- a/datacap_v10/Cargo.toml
+++ b/datacap_v10/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "fil_actor_datacap_v10"
+description = "Builtin data cap actor for Filecoin"
+version = "10.0.0"
+license = "MIT OR Apache-2.0"
+authors = ["Protocol Labs", "Filecoin Core Devs"]
+edition = "2018"
+repository = "https://github.com/filecoin-project/builtin-actors"
+keywords = ["filecoin", "web3", "wasm"]
+
+[lib]
+## lib is necessary for integration tests
+## cdylib is necessary for Wasm build
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+fil_actors_runtime_v10 = { workspace = true }
+cid = { workspace = true }
+frc42_dispatch = { workspace = true }
+frc46_token = { workspace = true }
+fvm_actor_utils = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+fvm_ipld_hamt = { workspace = true }
+fvm_shared = { workspace = true }
+lazy_static = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+log = { workspace = true }

--- a/datacap_v10/src/lib.rs
+++ b/datacap_v10/src/lib.rs
@@ -1,0 +1,37 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use frc46_token::token::TOKEN_PRECISION;
+use fvm_shared::METHOD_CONSTRUCTOR;
+use num_derive::FromPrimitive;
+
+pub use self::state::State;
+pub use self::types::*;
+
+mod state;
+pub mod testing;
+mod types;
+
+pub const DATACAP_GRANULARITY: u64 = TOKEN_PRECISION;
+
+/// Datacap actor methods available
+#[derive(FromPrimitive)]
+#[repr(u64)]
+pub enum Method {
+    Constructor = METHOD_CONSTRUCTOR,
+    MintExported = frc42_dispatch::method_hash!("Mint"),
+    DestroyExported = frc42_dispatch::method_hash!("Destroy"),
+    NameExported = frc42_dispatch::method_hash!("Name"),
+    SymbolExported = frc42_dispatch::method_hash!("Symbol"),
+    GranularityExported = frc42_dispatch::method_hash!("Granularity"),
+    TotalSupplyExported = frc42_dispatch::method_hash!("TotalSupply"),
+    BalanceExported = frc42_dispatch::method_hash!("Balance"),
+    TransferExported = frc42_dispatch::method_hash!("Transfer"),
+    TransferFromExported = frc42_dispatch::method_hash!("TransferFrom"),
+    IncreaseAllowanceExported = frc42_dispatch::method_hash!("IncreaseAllowance"),
+    DecreaseAllowanceExported = frc42_dispatch::method_hash!("DecreaseAllowance"),
+    RevokeAllowanceExported = frc42_dispatch::method_hash!("RevokeAllowance"),
+    BurnExported = frc42_dispatch::method_hash!("Burn"),
+    BurnFromExported = frc42_dispatch::method_hash!("BurnFrom"),
+    AllowanceExported = frc42_dispatch::method_hash!("Allowance"),
+}

--- a/datacap_v10/src/state.rs
+++ b/datacap_v10/src/state.rs
@@ -1,0 +1,40 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use frc46_token::token;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::tuple::*;
+use fvm_shared::address::Address;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::error::ExitCode;
+use fvm_shared::ActorID;
+
+use fil_actors_runtime_v10::{ActorError, AsActorError};
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct State {
+    pub governor: Address,
+    pub token: token::state::TokenState,
+}
+
+impl State {
+    pub fn new<BS: Blockstore>(store: &BS, governor: Address) -> Result<State, ActorError> {
+        let token_state = token::state::TokenState::new(store)
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to create token state")?;
+        Ok(State {
+            governor,
+            token: token_state,
+        })
+    }
+
+    // Visible for testing
+    pub fn balance<BS: Blockstore>(
+        &self,
+        bs: &BS,
+        owner: ActorID,
+    ) -> Result<TokenAmount, ActorError> {
+        self.token
+            .get_balance(bs, owner)
+            .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to get balance")
+    }
+}

--- a/datacap_v10/src/testing.rs
+++ b/datacap_v10/src/testing.rs
@@ -1,0 +1,27 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use frc46_token::token::state::StateSummary;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_shared::address::Protocol;
+
+use fil_actors_runtime_v10::MessageAccumulator;
+
+use crate::{State, DATACAP_GRANULARITY};
+
+/// Checks internal invariants of data cap token actor state.
+pub fn check_state_invariants<BS: Blockstore>(
+    state: &State,
+    store: &BS,
+) -> (StateSummary, MessageAccumulator) {
+    let acc = MessageAccumulator::default();
+    acc.require(
+        state.governor.protocol() == Protocol::ID,
+        "governor must be ID address",
+    );
+    let (summary, msgs) = state.token.check_invariants(store, DATACAP_GRANULARITY);
+    for e in msgs {
+        acc.add(e.to_string());
+    }
+    (summary, acc)
+}

--- a/datacap_v10/src/types.rs
+++ b/datacap_v10/src/types.rs
@@ -1,0 +1,28 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fvm_ipld_encoding::tuple::*;
+use fvm_shared::address::Address;
+use fvm_shared::econ::TokenAmount;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct MintParams {
+    // Recipient of the newly minted tokens.
+    pub to: Address,
+    // Amount of tokens to mint.
+    pub amount: TokenAmount,
+    // Addresses to be granted effectively-infinite operator allowance for the recipient.
+    pub operators: Vec<Address>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+pub struct DestroyParams {
+    pub owner: Address,
+    pub amount: TokenAmount,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize_tuple, Deserialize_tuple)]
+#[serde(transparent)]
+pub struct GranularityReturn {
+    pub granularity: u64,
+}

--- a/eam_v10/Cargo.toml
+++ b/eam_v10/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "fil_actor_eam_v10"
+description = "Builtin Ethereum address manager actor for Filecoin"
+version = "10.0.0"
+license = "MIT OR Apache-2.0"
+authors = ["Protocol Labs", "Filecoin Core Devs"]
+edition = "2021"
+repository = "https://github.com/filecoin-project/builtin-actors"
+keywords = ["filecoin", "web3", "wasm", "evm"]
+
+[lib]
+## lib is necessary for integration tests
+## cdylib is necessary for Wasm build
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+fil_actors_runtime_v10 = { workspace = true }
+serde = { workspace = true }
+serde_tuple = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = { workspace = true }
+multihash = { workspace = true }
+cid = { workspace = true }
+fvm_shared = { workspace = true }
+num-traits = { workspace = true }
+num-derive = { workspace = true }
+fil_actors_evm_shared = { version = "10.0.0", path = "../evm_v10/shared" }

--- a/eam_v10/src/ext.rs
+++ b/eam_v10/src/ext.rs
@@ -1,0 +1,50 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use cid::Cid;
+use fvm_ipld_encoding::tuple::*;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::Address;
+
+pub mod init {
+
+    use super::*;
+
+    pub const EXEC4_METHOD: u64 = 3;
+
+    /// Init actor Exec4 Params
+    #[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+    pub struct Exec4Params {
+        pub code_cid: Cid,
+        pub constructor_params: RawBytes,
+        pub subaddress: RawBytes,
+    }
+
+    /// Init actor Exec4 Return value
+    #[derive(Serialize_tuple, Deserialize_tuple, Debug)]
+    pub struct Exec4Return {
+        /// ID based address for created actor
+        pub id_address: Address,
+        /// Reorg safe address for actor
+        pub robust_address: Address,
+    }
+}
+
+pub mod evm {
+    use super::*;
+    use fil_actors_evm_shared::address::EthAddress;
+
+    #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+    pub struct ConstructorParams {
+        /// The actor's "creator" (specified by the EAM).
+        pub creator: EthAddress,
+        /// The initcode that will construct the new EVM actor.
+        pub initcode: RawBytes,
+    }
+
+    pub const RESURRECT_METHOD: u64 = 2;
+}
+
+pub mod account {
+    pub const PUBKEY_ADDRESS_METHOD: u64 = 2;
+}

--- a/eam_v10/src/lib.rs
+++ b/eam_v10/src/lib.rs
@@ -1,0 +1,16 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fvm_shared::METHOD_CONSTRUCTOR;
+
+pub mod ext;
+use num_derive::FromPrimitive;
+
+#[derive(FromPrimitive)]
+#[repr(u64)]
+pub enum Method {
+    Constructor = METHOD_CONSTRUCTOR,
+    Create = 2,
+    Create2 = 3,
+    CreateExternal = 4,
+}

--- a/ethaccount_v10/Cargo.toml
+++ b/ethaccount_v10/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "fil_actor_ethaccount_v10"
+description = "Builtin Ethereum Externally Owned Address actor for Filecoin"
+version = "10.0.0"
+license = "MIT OR Apache-2.0"
+authors = ["Protocol Labs", "Filecoin Core Devs"]
+edition = "2021"
+repository = "https://github.com/filecoin-project/builtin-actors"
+keywords = ["filecoin", "web3", "wasm", "evm"]
+
+[lib]
+## lib is necessary for integration tests
+## cdylib is necessary for Wasm build
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+serde = { workspace = true }
+fvm_ipld_encoding = "0.3.3"
+fvm_shared = { workspace = true }
+num-traits = { workspace = true }
+num-derive = { workspace = true }

--- a/ethaccount_v10/src/lib.rs
+++ b/ethaccount_v10/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+pub mod types;
+
+use fvm_shared::METHOD_CONSTRUCTOR;
+use num_derive::FromPrimitive;
+
+/// Ethereum Account actor methods.
+#[derive(FromPrimitive)]
+#[repr(u64)]
+pub enum Method {
+    Constructor = METHOD_CONSTRUCTOR,
+}

--- a/ethaccount_v10/src/types.rs
+++ b/ethaccount_v10/src/types.rs
@@ -1,0 +1,13 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fvm_ipld_encoding::strict_bytes;
+use fvm_ipld_encoding::tuple::*;
+
+#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct AuthenticateMessageParams {
+    #[serde(with = "strict_bytes")]
+    pub signature: Vec<u8>,
+    #[serde(with = "strict_bytes")]
+    pub message: Vec<u8>,
+}

--- a/evm_v10/Cargo.toml
+++ b/evm_v10/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "fil_actor_evm_v10"
+description = "Builtin EVM actor for Filecoin"
+version = "10.0.0"
+license = "MIT OR Apache-2.0"
+authors = ["Protocol Labs", "Filecoin Core Devs"]
+edition = "2021"
+repository = "https://github.com/filecoin-project/builtin-actors"
+keywords = ["filecoin", "web3", "wasm", "evm"]
+
+[lib]
+## lib is necessary for integration tests
+## cdylib is necessary for Wasm build
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+fil_actors_runtime_v10 = { workspace = true }
+fvm_shared = { workspace = true }
+serde = { workspace = true }
+serde_tuple = { workspace = true }
+num-traits = { workspace = true }
+num-derive = { workspace = true }
+cid = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }
+fvm_ipld_blockstore = { workspace = true }
+fvm_ipld_encoding = "0.3.3"
+multihash = { workspace = true }
+hex = { workspace = true }
+hex-literal = { workspace = true }
+substrate-bn = { version = "0.6.0", default-features = false }
+frc42_dispatch = { workspace = true }
+fil_actors_evm_shared = { version = "10.0.0", path = "shared" }

--- a/evm_v10/shared/Cargo.toml
+++ b/evm_v10/shared/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "fil_actors_evm_shared"
+description = "Shared libraries for the built-in EVM actor for Filecoin"
+version = "10.0.0"
+license = "MIT OR Apache-2.0"
+authors = ["Protocol Labs", "Filecoin Core Devs"]
+edition = "2021"
+repository = "https://github.com/filecoin-project/builtin-actors"
+keywords = ["filecoin", "web3", "wasm", "evm"]
+
+[dependencies]
+serde = { workspace = true }
+fvm_shared = { version = "3.0.0", default-features = false }
+fil_actors_runtime_v10 = { workspace = true }
+fvm_ipld_encoding = "0.3.3"
+uint = { version = "0.9.3", default-features = false }
+hex = { workspace = true }

--- a/evm_v10/shared/src/address.rs
+++ b/evm_v10/shared/src/address.rs
@@ -1,0 +1,182 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::uints::U256;
+use fil_actors_runtime_v10::EAM_ACTOR_ID;
+use fvm_ipld_encoding::{serde, strict_bytes};
+use fvm_shared::address::Address;
+use fvm_shared::ActorID;
+
+/// A Filecoin address as represented in the FEVM runtime (also called EVM-form).
+#[derive(serde::Deserialize, serde::Serialize, PartialEq, Eq, Clone, Copy)]
+pub struct EthAddress(#[serde(with = "strict_bytes")] pub [u8; 20]);
+
+/// Converts a U256 to an EthAddress by taking the lower 20 bytes.
+///
+/// Per the EVM spec, this simply discards the high bytes.
+impl From<U256> for EthAddress {
+    fn from(v: U256) -> Self {
+        let mut bytes = [0u8; 32];
+        v.to_big_endian(&mut bytes);
+        Self(bytes[12..].try_into().unwrap())
+    }
+}
+
+impl std::fmt::Debug for EthAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&hex::encode(self.0))
+    }
+}
+
+impl From<EthAddress> for Address {
+    fn from(addr: EthAddress) -> Self {
+        From::from(&addr)
+    }
+}
+
+impl From<&EthAddress> for Address {
+    fn from(addr: &EthAddress) -> Self {
+        if let Some(id) = addr.as_id() {
+            Address::new_id(id)
+        } else {
+            Address::new_delegated(EAM_ACTOR_ID, addr.as_ref()).unwrap()
+        }
+    }
+}
+
+impl EthAddress {
+    /// Returns a "null" address.
+    pub const fn null() -> Self {
+        Self([0u8; 20])
+    }
+
+    /// Returns an EVM-form ID address from actor ID.
+    pub fn from_id(id: u64) -> EthAddress {
+        let mut bytes = [0u8; 20];
+        bytes[0] = 0xff;
+        bytes[12..].copy_from_slice(&id.to_be_bytes());
+        EthAddress(bytes)
+    }
+
+    /// Interpret the EVM word as an ID address in EVM-form, and return a Filecoin ID address if
+    /// that's the case.
+    ///
+    /// An ID address starts with 0xff (msb), and contains the u64 in the last 8 bytes.
+    /// We assert that everything in between are 0x00, otherwise we've gotten an illegal address.
+    ///
+    /// 0    1-11       12
+    /// 0xff \[0x00...] [id address...]
+    pub fn as_id(&self) -> Option<ActorID> {
+        if !self.is_id() {
+            return None;
+        }
+        Some(u64::from_be_bytes(self.0[12..].try_into().unwrap()))
+    }
+
+    /// Returns this Address as an EVM word.
+    #[inline]
+    pub fn as_evm_word(&self) -> U256 {
+        U256::from_big_endian(&self.0)
+    }
+
+    /// Returns true if this is the null/zero EthAddress.
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        self.0 == [0; 20]
+    }
+
+    /// Returns true if the EthAddress refers to an address in the precompile range.
+    /// [reference](https://github.com/filecoin-project/ref-fvm/issues/1164#issuecomment-1371304676)
+    #[inline]
+    pub fn is_precompile(&self) -> bool {
+        // Exact index is not checked since it is unknown to the EAM what precompiles exist in the EVM actor.
+        // 0 indexes of both ranges are not assignable as well but are _not_ precompile address.
+        let [prefix, middle @ .., _index] = self.0;
+        (prefix == 0xfe || prefix == 0x00) && middle == [0u8; 18]
+    }
+
+    /// Returns true if the EthAddress is an actor ID embedded in an eth address.
+    #[inline]
+    pub fn is_id(&self) -> bool {
+        self.0[0] == 0xff && self.0[1..12].iter().all(|&i| i == 0)
+    }
+}
+
+impl AsRef<[u8]> for EthAddress {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EthAddress;
+    use crate::uints::U256;
+
+    // padding (12 bytes)
+    const TYPE_PADDING: &[u8] = &[0; 12];
+    // ID address marker (1 byte)
+    const ID_ADDRESS_MARKER: &[u8] = &[0xff];
+    // ID address marker (1 byte)
+    const GOOD_ADDRESS_PADDING: &[u8] = &[
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]; // padding for inner u64 (11 bytes)
+
+    macro_rules! id_address_test {
+        ($($name:ident: $input:expr => $expectation:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let evm_bytes = $input.concat();
+                let evm_addr = EthAddress::from(U256::from(evm_bytes.as_slice()));
+                assert_eq!(
+                    evm_addr.as_id(),
+                    $expectation
+                );
+
+                // test inverse conversion, if a valid ID address was supplied
+                if let Some(fil_id) = $expectation {
+                    assert_eq!(EthAddress::from_id(fil_id), evm_addr);
+                }
+            }
+        )*
+        };
+    }
+
+    id_address_test! {
+        good_address_1: [
+            TYPE_PADDING,
+            ID_ADDRESS_MARKER,
+            GOOD_ADDRESS_PADDING,
+            vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01].as_slice() // ID address (u64 big endian) (8 bytes)
+        ] => Some(1),
+
+        good_address_2: [
+            TYPE_PADDING,
+            ID_ADDRESS_MARKER,
+            GOOD_ADDRESS_PADDING,
+            vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff].as_slice() // ID address (u64 big endian) (8 bytes)
+        ] => Some(u16::MAX as u64),
+
+        bad_marker: [
+            TYPE_PADDING,
+            &[0xfa],
+            GOOD_ADDRESS_PADDING,
+            vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01].as_slice() // ID address (u64 big endian) (8 bytes)
+        ] => None,
+
+        bad_padding: [
+            TYPE_PADDING,
+            ID_ADDRESS_MARKER,
+            &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01], // bad padding
+            vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01].as_slice() // ID address (u64 big endian) (8 bytes)
+        ] => None,
+
+        bad_marker_and_padding: [
+            TYPE_PADDING,
+            &[0xfa],
+            &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01], // bad padding
+            vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01].as_slice() // ID address (u64 big endian) (8 bytes)
+        ] => None,
+    }
+}

--- a/evm_v10/shared/src/lib.rs
+++ b/evm_v10/shared/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+pub mod address;
+pub mod uints;

--- a/evm_v10/shared/src/uints.rs
+++ b/evm_v10/shared/src/uints.rs
@@ -1,0 +1,345 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+// to silence construct_uint! clippy warnings
+// see https://github.com/paritytech/parity-common/issues/660
+#![allow(clippy::ptr_offset_with_cast, clippy::assign_op_pattern)]
+
+#[doc(inline)]
+pub use uint::byteorder;
+
+use serde::{Deserialize, Serialize};
+//use substrate_bn::arith;
+
+use {
+    fvm_shared::bigint::BigInt, fvm_shared::econ::TokenAmount, std::cmp::Ordering, std::fmt,
+    uint::construct_uint,
+};
+
+construct_uint! { pub struct U256(4); } // ethereum word size
+construct_uint! { pub struct U512(8); } // used for addmod and mulmod opcodes
+
+// Convenience method for comparing against a small value.
+impl PartialOrd<u64> for U256 {
+    fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+        if self.0[3] > 0 || self.0[2] > 0 || self.0[1] > 0 {
+            Some(Ordering::Greater)
+        } else {
+            self.0[0].partial_cmp(other)
+        }
+    }
+}
+
+impl PartialEq<u64> for U256 {
+    fn eq(&self, other: &u64) -> bool {
+        self.0[0] == *other && self.0[1] == 0 && self.0[2] == 0 && self.0[3] == 0
+    }
+}
+
+impl U256 {
+    pub const BITS: u32 = 256;
+    pub const ZERO: Self = U256::from_u64(0);
+    pub const ONE: Self = U256::from_u64(1);
+    pub const I128_MIN: Self = U256([0, 0, 0, i64::MIN as u64]);
+
+    #[inline(always)]
+    pub const fn from_u128_words(high: u128, low: u128) -> U256 {
+        U256([
+            low as u64,
+            (low >> u64::BITS) as u64,
+            high as u64,
+            (high >> u64::BITS) as u64,
+        ])
+    }
+
+    #[inline(always)]
+    pub const fn from_u64(value: u64) -> U256 {
+        U256([value, 0, 0, 0])
+    }
+
+    #[inline(always)]
+    pub const fn i256_is_negative(&self) -> bool {
+        (self.0[3] as i64) < 0
+    }
+
+    /// turns a i256 value to negative
+    #[inline(always)]
+    pub fn i256_neg(&self) -> U256 {
+        if self.is_zero() {
+            U256::ZERO
+        } else {
+            !*self + U256::ONE
+        }
+    }
+
+    #[inline(always)]
+    pub fn i256_cmp(&self, other: &U256) -> Ordering {
+        // true > false:
+        // - true < positive:
+        match other.i256_is_negative().cmp(&self.i256_is_negative()) {
+            Ordering::Equal => self.cmp(other),
+            sign_cmp => sign_cmp,
+        }
+    }
+
+    #[inline]
+    pub fn i256_div(&self, other: &U256) -> U256 {
+        if self.is_zero() || other.is_zero() {
+            // EVM defines X/0 to be 0.
+            return U256::ZERO;
+        }
+
+        // min-negative-value can't be represented as a positive value, but we don't need to.
+        // NOTE: we've already checked that 'second' isn't zero above.
+        if (self, other) == (&U256::I128_MIN, &U256::ONE) {
+            return U256::I128_MIN;
+        }
+
+        let mut first = *self;
+        let mut second = *other;
+
+        // Record and strip the signs. We add them back at the end.
+        let first_neg = first.i256_is_negative();
+        let second_neg = second.i256_is_negative();
+
+        if first_neg {
+            first = first.i256_neg()
+        }
+
+        if second_neg {
+            second = second.i256_neg()
+        }
+
+        let d = first / second;
+
+        // Flip the sign back if necessary.
+        if d.is_zero() || first_neg == second_neg {
+            d
+        } else {
+            d.i256_neg()
+        }
+    }
+
+    #[inline]
+    pub fn i256_mod(&self, other: &U256) -> U256 {
+        if self.is_zero() || other.is_zero() {
+            // X % 0  or 0 % X is always 0.
+            return U256::ZERO;
+        }
+
+        let mut first = *self;
+        let mut second = *other;
+
+        // Record and strip the sign.
+        let negative = first.i256_is_negative();
+        if negative {
+            first = first.i256_neg();
+        }
+
+        if second.i256_is_negative() {
+            second = second.i256_neg()
+        }
+
+        let r = first % second;
+
+        // Restore the sign.
+        if negative && !r.is_zero() {
+            r.i256_neg()
+        } else {
+            r
+        }
+    }
+
+    pub fn to_bytes(&self) -> [u8; 32] {
+        let mut buf = [0u8; 32];
+        self.to_big_endian(&mut buf);
+        buf
+    }
+
+    /// Returns the low 64 bits, saturating the value to u64 max if it is larger
+    pub fn to_u64_saturating(&self) -> u64 {
+        if self.bits() > 64 {
+            u64::MAX
+        } else {
+            self.0[0]
+        }
+    }
+}
+
+impl U512 {
+    pub fn low_u256(&self) -> U256 {
+        let [a, b, c, d, ..] = self.0;
+        U256([a, b, c, d])
+    }
+}
+
+impl From<&TokenAmount> for U256 {
+    fn from(amount: &TokenAmount) -> U256 {
+        let (_, bytes) = amount.atto().to_bytes_be();
+        U256::from(bytes.as_slice())
+    }
+}
+
+impl From<U256> for U512 {
+    fn from(v: U256) -> Self {
+        let [a, b, c, d] = v.0;
+        U512([a, b, c, d, 0, 0, 0, 0])
+    }
+}
+
+impl From<&U256> for TokenAmount {
+    fn from(ui: &U256) -> TokenAmount {
+        let mut bits = [0u8; 32];
+        ui.to_big_endian(&mut bits);
+        TokenAmount::from_atto(BigInt::from_bytes_be(fvm_shared::bigint::Sign::Plus, &bits))
+    }
+}
+
+impl Serialize for U256 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut bytes = [0u8; 32];
+        self.to_big_endian(&mut bytes);
+        serializer.serialize_bytes(zeroless_view(&bytes))
+    }
+}
+
+impl<'de> Deserialize<'de> for U256 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = U256;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "at most 32 bytes")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if v.len() > 32 {
+                    return Err(serde::de::Error::invalid_length(v.len(), &self));
+                }
+                Ok(U256::from_big_endian(v))
+            }
+        }
+        deserializer.deserialize_bytes(Visitor)
+    }
+}
+
+fn zeroless_view(v: &impl AsRef<[u8]>) -> &[u8] {
+    let v = v.as_ref();
+    &v[v.iter().take_while(|&&b| b == 0).count()..]
+}
+
+#[cfg(test)]
+mod tests {
+    use fvm_ipld_encoding::{BytesDe, BytesSer, RawBytes};
+
+    use {super::*, core::num::Wrapping};
+
+    #[test]
+    fn div_i256() {
+        assert_eq!(Wrapping(i8::MIN) / Wrapping(-1), Wrapping(i8::MIN));
+        assert_eq!(i8::MAX / -1, -i8::MAX);
+
+        let zero = U256::ZERO;
+        let one = U256::ONE;
+        let one_hundred = U256::from(100);
+        let fifty = U256::from(50);
+        let two = U256::from(2);
+        let neg_one_hundred = U256::from(100);
+        let minus_one = U256::from(1);
+        let max_value = U256::from(2).pow(255.into()) - 1;
+        let neg_max_value = U256::from(2).pow(255.into()) - 1;
+
+        assert_eq!(U256::I128_MIN.i256_div(&minus_one), U256::I128_MIN);
+        assert_eq!(U256::I128_MIN.i256_div(&one), U256::I128_MIN);
+        assert_eq!(one.i256_div(&U256::I128_MIN), zero);
+        assert_eq!(max_value.i256_div(&one), max_value);
+        assert_eq!(max_value.i256_div(&minus_one), neg_max_value);
+        assert_eq!(one_hundred.i256_div(&minus_one), neg_one_hundred);
+        assert_eq!(one_hundred.i256_div(&two), fifty);
+
+        assert_eq!(zero.i256_div(&zero), zero);
+        assert_eq!(one.i256_div(&zero), zero);
+        assert_eq!(zero.i256_div(&one), zero);
+    }
+
+    #[test]
+    fn mod_i256() {
+        let zero = U256::ZERO;
+        let one = U256::ONE;
+        let one_hundred = U256::from(100);
+        let two = U256::from(2);
+        let three = U256::from(3);
+
+        let neg_one_hundred = U256::from(100).i256_neg();
+        let minus_one = U256::from(1).i256_neg();
+        let neg_three = U256::from(3).i256_neg();
+        let max_value = U256::from(2).pow(255.into()) - 1;
+
+        // zero
+        assert_eq!(minus_one.i256_mod(&U256::ZERO), U256::ZERO);
+        assert_eq!(max_value.i256_mod(&U256::ZERO), U256::ZERO);
+        assert_eq!(U256::ZERO.i256_mod(&U256::ZERO), U256::ZERO);
+
+        assert_eq!(minus_one.i256_mod(&two), minus_one);
+        assert_eq!(U256::I128_MIN.i256_mod(&one), 0);
+        assert_eq!(one.i256_mod(&U256::I128_MIN), one);
+        assert_eq!(one.i256_mod(&U256::from(i128::MAX)), one);
+
+        assert_eq!(max_value.i256_mod(&minus_one), zero);
+        assert_eq!(neg_one_hundred.i256_mod(&minus_one), zero);
+        assert_eq!(one_hundred.i256_mod(&two), zero);
+        assert_eq!(one_hundred.i256_mod(&neg_three), one);
+
+        assert_eq!(neg_one_hundred.i256_mod(&three), minus_one);
+
+        let a = U256::from(95).i256_neg();
+        let b = U256::from(256);
+        assert_eq!(a % b, U256::from(161))
+    }
+
+    #[test]
+    fn negative_i256() {
+        assert_eq!(U256::ZERO.i256_neg(), U256::ZERO);
+
+        let one = U256::ONE.i256_neg();
+        assert!(one.i256_is_negative());
+
+        let neg_one = U256::from(&[0xff; 32]);
+        let pos_one = neg_one.i256_neg();
+        assert_eq!(pos_one, U256::ONE);
+    }
+
+    #[test]
+    fn u256_serde() {
+        let encoded = RawBytes::serialize(U256::from(0x4d2)).unwrap();
+        let BytesDe(bytes) = encoded.deserialize().unwrap();
+        assert_eq!(bytes, &[0x04, 0xd2]);
+        let decoded: U256 = encoded.deserialize().unwrap();
+        assert_eq!(decoded, 0x4d2);
+    }
+
+    #[test]
+    fn u256_empty() {
+        let encoded = RawBytes::serialize(U256::from(0)).unwrap();
+        let BytesDe(bytes) = encoded.deserialize().unwrap();
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn u256_overflow() {
+        let encoded = RawBytes::serialize(BytesSer(&[1; 33])).unwrap();
+        encoded
+            .deserialize::<U256>()
+            .expect_err("should have failed to decode an over-large u256");
+    }
+}

--- a/evm_v10/src/ext.rs
+++ b/evm_v10/src/ext.rs
@@ -1,0 +1,33 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+pub mod eam {
+    use fil_actors_evm_shared::address::EthAddress;
+    use fvm_ipld_encoding::{strict_bytes, tuple::*};
+    use fvm_shared::address::Address;
+
+    pub const CREATE_METHOD_NUM: u64 = 2;
+    pub const CREATE2_METHOD_NUM: u64 = 3;
+
+    #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+    pub struct CreateParams {
+        #[serde(with = "strict_bytes")]
+        pub code: Vec<u8>,
+        pub nonce: u64,
+    }
+
+    #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+    pub struct Create2Params {
+        #[serde(with = "strict_bytes")]
+        pub code: Vec<u8>,
+        #[serde(with = "strict_bytes")]
+        pub salt: [u8; 32],
+    }
+
+    #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct CreateReturn {
+        pub actor_id: u64,
+        pub robust_address: Option<Address>,
+        pub eth_address: EthAddress,
+    }
+}

--- a/evm_v10/src/lib.rs
+++ b/evm_v10/src/lib.rs
@@ -1,0 +1,41 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fvm_shared::error::ExitCode;
+
+use fvm_shared::METHOD_CONSTRUCTOR;
+use num_derive::FromPrimitive;
+
+pub use types::*;
+
+#[doc(hidden)]
+pub mod ext;
+pub(crate) mod reader;
+mod state;
+mod types;
+
+pub use state::*;
+
+pub const EVM_CONTRACT_REVERTED: ExitCode = ExitCode::new(33);
+pub const EVM_CONTRACT_INVALID_INSTRUCTION: ExitCode = ExitCode::new(34);
+pub const EVM_CONTRACT_UNDEFINED_INSTRUCTION: ExitCode = ExitCode::new(35);
+pub const EVM_CONTRACT_STACK_UNDERFLOW: ExitCode = ExitCode::new(36);
+pub const EVM_CONTRACT_STACK_OVERFLOW: ExitCode = ExitCode::new(37);
+pub const EVM_CONTRACT_ILLEGAL_MEMORY_ACCESS: ExitCode = ExitCode::new(38);
+pub const EVM_CONTRACT_BAD_JUMPDEST: ExitCode = ExitCode::new(39);
+pub const EVM_CONTRACT_SELFDESTRUCT_FAILED: ExitCode = ExitCode::new(40);
+
+pub const NATIVE_METHOD_SIGNATURE: &str = "handle_filecoin_method(uint64,uint64,bytes)";
+pub const NATIVE_METHOD_SELECTOR: [u8; 4] = [0x86, 0x8e, 0x10, 0xc4];
+
+#[derive(FromPrimitive)]
+#[repr(u64)]
+pub enum Method {
+    Constructor = METHOD_CONSTRUCTOR,
+    Resurrect = 2,
+    GetBytecode = 3,
+    GetBytecodeHash = 4,
+    GetStorageAt = 5,
+    InvokeContractDelegate = 6,
+    InvokeContract = frc42_dispatch::method_hash!("InvokeEVM"),
+}

--- a/evm_v10/src/reader.rs
+++ b/evm_v10/src/reader.rs
@@ -1,0 +1,212 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::fmt::Display;
+
+use fil_actors_evm_shared::uints::U256;
+use fvm_shared::error::ExitCode;
+use substrate_bn::{AffineG1, CurveError, FieldError, Fq, Fr, Group, G1};
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct OverflowError;
+
+impl Display for OverflowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("value overflowed")
+    }
+}
+
+/// A `Value` is a type that can be read from a `ValueReader`. These values are usually used in
+/// solidity inputs/outputs.
+pub(crate) trait Value: Sized {
+    type Error;
+    fn read(reader: &mut ValueReader) -> Result<Self, Self::Error>;
+}
+
+impl Value for G1 {
+    type Error = CurveError;
+    fn read(reader: &mut ValueReader) -> Result<Self, Self::Error> {
+        let x: Fq = reader.read_value()?;
+        let y: Fq = reader.read_value()?;
+
+        Ok(if x.is_zero() && y.is_zero() {
+            G1::zero()
+        } else {
+            AffineG1::new(x, y)
+                .map_err(|_| CurveError::NotMember)?
+                .into()
+        })
+    }
+}
+
+impl Value for Fq {
+    type Error = FieldError;
+    fn read(reader: &mut ValueReader) -> Result<Self, Self::Error> {
+        Fq::from_slice(&reader.read_fixed::<32>())
+    }
+}
+
+impl Value for Fr {
+    type Error = FieldError;
+    fn read(reader: &mut ValueReader) -> Result<Self, Self::Error> {
+        Fr::from_slice(&reader.read_fixed::<32>())
+    }
+}
+
+impl Value for ExitCode {
+    type Error = OverflowError;
+
+    fn read(reader: &mut ValueReader) -> Result<Self, Self::Error> {
+        Ok(ExitCode::new(reader.read_value()?))
+    }
+}
+
+impl Value for U256 {
+    type Error = FieldError;
+    fn read(reader: &mut ValueReader) -> Result<Self, Self::Error> {
+        Ok(U256::from(reader.read_fixed::<32>()))
+    }
+}
+
+impl Value for [u8; 32] {
+    type Error = std::convert::Infallible;
+    fn read(reader: &mut ValueReader) -> Result<Self, Self::Error> {
+        Ok(reader.read_fixed())
+    }
+}
+
+impl Value for u8 {
+    type Error = OverflowError;
+    fn read(reader: &mut ValueReader) -> Result<Self, Self::Error> {
+        reader.drop_zeros::<31>()?;
+        Ok(reader.read_byte())
+    }
+}
+
+macro_rules! impl_value_int {
+    ($($t:ty)*) => {
+        $(
+            impl Value for $t {
+                type Error = OverflowError;
+                fn read(reader: &mut ValueReader) -> Result<Self, Self::Error> {
+                    const ZEROS: usize = 32 - ((<$t>::BITS as usize) / 8);
+
+                    reader.drop_zeros::<ZEROS>()?;
+                    // Type ensures our remaining len
+                    Ok(<$t>::from_be_bytes(reader.read_fixed()))
+                }
+            }
+        )*
+    };
+}
+
+impl_value_int!(u16 i16 u32 i32 u64 i64);
+
+/// Provides a nice API interface for reading Values from input. This API treats the input as if it
+/// is followed by infinite zeros.
+pub(crate) struct ValueReader<'a> {
+    slice: &'a [u8],
+}
+
+impl<'a> ValueReader<'a> {
+    /// Drop a fixed number of bytes, and return an error if said bytes are not zeros.
+    pub fn drop_zeros<const S: usize>(&mut self) -> Result<(), OverflowError> {
+        let split = S.min(self.slice.len());
+        let (a, b) = self.slice.split_at(split);
+        self.slice = b;
+        if a.iter().all(|&i| i == 0) {
+            Ok(())
+        } else {
+            Err(OverflowError)
+        }
+    }
+
+    /// Read a single byte, or 0 if there's no remaining input.
+    ///
+    /// NOTE: This won't read 32 bytes, it'll just read a _single_ byte.
+    pub fn read_byte(&mut self) -> u8 {
+        if let Some((&first, rest)) = self.slice.split_first() {
+            self.slice = rest;
+            first
+        } else {
+            0
+        }
+    }
+
+    /// Read a fixed number of bytes from the input, zero-padding as necessary.
+    ///
+    /// NOTE: this won't read in 32byte chunks, it'll read the specified number of bytes exactly.
+    pub fn read_fixed<const S: usize>(&mut self) -> [u8; S] {
+        let mut out = [0u8; S];
+        let split = S.min(self.slice.len());
+        let (a, b) = self.slice.split_at(split);
+        self.slice = b;
+        out[..split].copy_from_slice(a);
+        out
+    }
+
+    /// Read a single value from the input. The value's type decides how much input it needs
+    /// to read.
+    ///
+    /// Most values will be read in 32 byte chunks, but that's up to the value's implementation.
+    pub fn read_value<V>(&mut self) -> Result<V, V::Error>
+    where
+        V: Value,
+    {
+        Value::read(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_read_fixed() {
+        let mut reader = ValueReader::new(&[1, 2, 3]);
+        let empty: [u8; 0] = [];
+        assert_eq!(reader.read_fixed::<2>(), [1, 2]);
+        assert_eq!(reader.read_fixed::<0>(), empty);
+        assert_eq!(reader.read_fixed::<5>(), [3u8, 0, 0, 0, 0]);
+        assert_eq!(reader.read_fixed::<3>(), [0, 0, 0]);
+    }
+
+    #[test]
+    fn test_right_pad() {
+        let mut reader = ValueReader::new(&[1, 2, 3]);
+        assert_eq!(reader.read_padded(2), &[1, 2][..]);
+        assert_eq!(reader.read_padded(2), &[3, 0][..]);
+        assert_eq!(reader.read_padded(2), &[0, 0][..]);
+    }
+
+    #[test]
+    fn test_int() {
+        let mut data = vec![0u8; 37];
+        data[31] = 1;
+        let mut reader = ValueReader::new(&data);
+        assert_eq!(reader.read_value::<u64>().unwrap(), 1);
+        assert_eq!(reader.read_value::<u64>().unwrap(), 0);
+
+        // Expect this to overflow now.
+        data[0] = 1;
+        let mut reader = ValueReader::new(&data);
+        assert_eq!(reader.read_value::<u64>().unwrap_err(), OverflowError);
+    }
+
+    #[test]
+    fn test_big_int() {
+        let mut reader = ValueReader::new(&[1, 2]);
+        assert_eq!(reader.read_biguint(1), 1u64.into());
+        assert_eq!(reader.read_biguint(3), 0x02_00_00u64.into());
+        assert_eq!(reader.read_biguint(5), 0u32.into());
+    }
+
+    #[test]
+    fn test_byte() {
+        let mut reader = ValueReader::new(&[1, 2]);
+        assert_eq!(reader.read_byte(), 1u8);
+        assert_eq!(reader.read_byte(), 2u8);
+        assert_eq!(reader.read_byte(), 0u8);
+        assert_eq!(reader.read_byte(), 0u8);
+    }
+}

--- a/evm_v10/src/state.rs
+++ b/evm_v10/src/state.rs
@@ -1,0 +1,172 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::array::TryFromSliceError;
+
+use fil_actors_evm_shared::uints::U256;
+use fvm_shared::ActorID;
+
+use cid::Cid;
+use fvm_ipld_encoding::strict_bytes;
+use fvm_ipld_encoding::tuple::*;
+use serde::{Deserialize, Serialize};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+
+/// A tombstone indicating that the contract has been self-destructed.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize_tuple, Deserialize_tuple)]
+pub struct Tombstone {
+    /// The message origin when this actor was self-destructed.
+    pub origin: ActorID,
+    /// The message nonce when this actor was self-destructed.
+    pub nonce: u64,
+}
+
+/// A Keccak256 digest of EVM bytecode.
+#[derive(Deserialize, Serialize, Clone, Copy, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct BytecodeHash(#[serde(with = "strict_bytes")] [u8; 32]);
+
+impl std::fmt::Debug for BytecodeHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("BytecodeHash")
+            .field(&format_args!("{}", self))
+            .finish()
+    }
+}
+
+impl std::fmt::Display for BytecodeHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        for b in self.0 {
+            write!(f, "{b:02X}")?;
+        }
+        Ok(())
+    }
+}
+
+impl BytecodeHash {
+    pub const ZERO: Self = Self([0; 32]);
+
+    /// Keccak256 hash of `[0xfe]`, "native bytecode"
+    pub const NATIVE_ACTOR: Self = Self(hex_literal::hex!(
+        "bcc90f2d6dada5b18e155c17a1c0a55920aae94f39857d39d0d8ed07ae8f228b"
+    ));
+
+    /// Keccak256 hash of `[]`, empty bytecode
+    pub const EMPTY: Self = Self(hex_literal::hex!(
+        "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    ));
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for BytecodeHash {
+    fn from(digest: [u8; 32]) -> Self {
+        BytecodeHash(digest)
+    }
+}
+
+impl From<BytecodeHash> for [u8; 32] {
+    fn from(digest: BytecodeHash) -> Self {
+        digest.0
+    }
+}
+
+impl From<BytecodeHash> for Vec<u8> {
+    fn from(digest: BytecodeHash) -> Self {
+        digest.0.into()
+    }
+}
+
+impl From<BytecodeHash> for U256 {
+    fn from(bytecode: BytecodeHash) -> Self {
+        let bytes: [u8; 32] = bytecode.into();
+        Self::from(bytes)
+    }
+}
+
+impl TryFrom<&[u8]> for BytecodeHash {
+    type Error = TryFromSliceError;
+
+    fn try_from(value: &[u8]) -> Result<Self, TryFromSliceError> {
+        Ok(Self(value.try_into()?))
+    }
+}
+
+/// Data stored by an EVM contract.
+/// This runs on the fvm-evm-runtime actor code cid.
+#[derive(Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct State {
+    /// The EVM contract bytecode resulting from calling the
+    /// initialization code by the constructor.
+    pub bytecode: Cid,
+
+    /// The EVM contract bytecode hash keccak256(bytecode)
+    pub bytecode_hash: BytecodeHash,
+
+    /// The EVM contract state dictionary.
+    /// All eth contract state is a map of U256 -> U256 values.
+    ///
+    /// KAMT<U256, U256>
+    pub contract_state: Cid,
+
+    /// The EVM nonce used to track how many times CREATE or CREATE2 have been called.
+    pub nonce: u64,
+
+    /// Possibly a tombstone if this actor has been self-destructed.
+    ///
+    /// In the EVM, self-destructed contracts are "alive" until the current top-level transaction
+    /// ends. We track this by recording the origin and nonce.
+    ///
+    /// Specifically:
+    ///
+    /// 1. On SELFDESTRUCT, they mark themselves as "deleted" (by setting a tombstone with the
+    ///    current origin/nonce), send away all funds, and return immediately.
+    /// 2. For the rest of the current transaction (as long as the tombstone's origin/nonce matches
+    ///    the currently executing top-level transaction) , the contract continues to behave
+    ///    normally.
+    /// 3. After the current transaction ends, the contract behaves as if it were an "empty"
+    ///    contract, kind of like an embryo. At this point, the contract can be "resurrected"
+    ///    (recreated) by via CREATE/CREATE2.
+    ///
+    /// See https://github.com/filecoin-project/ref-fvm/issues/1174 for some context.
+    pub tombstone: Option<Tombstone>,
+}
+
+#[cfg(test)]
+mod test {
+    use fvm_ipld_encoding::{from_slice, to_vec, BytesDe};
+
+    use crate::BytecodeHash;
+
+    #[test]
+    fn test_bytecode_hash_serde() {
+        let encoded = to_vec(&BytecodeHash::EMPTY).unwrap();
+        let BytesDe(decoded) = from_slice(&encoded).unwrap();
+        assert_eq!(
+            BytecodeHash::try_from(&decoded[..]).unwrap(),
+            BytecodeHash::EMPTY
+        );
+    }
+
+    #[test]
+    fn test_bytecode_hash_format() {
+        assert_eq!(
+            BytecodeHash::ZERO.to_string(),
+            "0000000000000000000000000000000000000000000000000000000000000000"
+        );
+        assert_eq!(
+            format!("{:#}", BytecodeHash::ZERO),
+            "0x0000000000000000000000000000000000000000000000000000000000000000"
+        );
+
+        assert_eq!(
+            format!("{:?}", BytecodeHash::ZERO),
+            "BytecodeHash(0000000000000000000000000000000000000000000000000000000000000000)"
+        );
+    }
+}

--- a/evm_v10/src/types.rs
+++ b/evm_v10/src/types.rs
@@ -1,0 +1,37 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use cid::Cid;
+use fil_actors_evm_shared::address::EthAddress;
+use fil_actors_evm_shared::uints::U256;
+use fvm_ipld_encoding::strict_bytes;
+use fvm_ipld_encoding::tuple::*;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::econ::TokenAmount;
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct ConstructorParams {
+    /// The actor's "creator" (specified by the EAM).
+    pub creator: EthAddress,
+    /// The initcode that will construct the new EVM actor.
+    pub initcode: RawBytes,
+}
+
+pub type ResurrectParams = ConstructorParams;
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct DelegateCallParams {
+    pub code: Cid,
+    /// The contract invocation parameters
+    #[serde(with = "strict_bytes")]
+    pub input: Vec<u8>,
+    /// The original caller's Eth address.
+    pub caller: EthAddress,
+    /// The value passed in the original call.
+    pub value: TokenAmount,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct GetStorageAtParams {
+    pub storage_key: U256,
+}

--- a/runtime_v10/src/builtin/singletons.rs
+++ b/runtime_v10/src/builtin/singletons.rs
@@ -25,6 +25,7 @@ define_singletons! {
     STORAGE_MARKET_ACTOR = 5,
     VERIFIED_REGISTRY_ACTOR = 6,
     DATACAP_TOKEN_ACTOR = 7,
+    EAM_ACTOR = 10,
     BURNT_FUNDS_ACTOR = 99,
 }
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Added new v10 builtin actors: `datacap`, `eam`, `evm`, `ethaccount`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Contributes to https://github.com/ChainSafe/forest/issues/2634


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->