### PR TITLE
improve lint checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,24 +34,6 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  clippy:
-    name: clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - run: rustup component add clippy
-      - name: Apt Dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          command: |
-            sudo make install-deps
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
-
   lint-all:
     name: All lint checks (lint audit spellcheck udeps)
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,18 +22,6 @@ jobs:
     - name: Run tests
       run: cargo test --all
 
-
-  fmt:
-    name: fmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
   lint-all:
     name: All lint checks (lint audit spellcheck udeps)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ install-deps:
 	apt-get update -y
 	apt-get install --no-install-recommends -y ocl-icd-opencl-dev protobuf-compiler
 
-clean-all:
-	cargo clean
-
 # Lints with everything we have in our CI arsenal
 lint-all: lint audit udeps
 
@@ -26,7 +23,7 @@ lint: clean lint-clippy
 	taplo lint
 	
 lint-clippy:
-	cargo clippy
+	cargo clippy --all-features -- -D warnings
 
 # Formats Rust and TOML files
 fmt:
@@ -38,4 +35,4 @@ clean:
 	@cargo clean
 	@echo "Done cleaning."
 
-.PHONY: clean clean-all lint lint-clippy install-lint-tools
+.PHONY: install-lint-tools install-deps lint-all audit udeps lint lint-clippy fmt clean


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- clippy was running twice for no reason
- `clean-all` was doing the same stuff as `clean`
- missing phony targets



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->