### PR TITLE
fix(ci): fix ci manifest errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/" # Location of package manifests
+    open-pull-requests-limit: 1
+    schedule:
+      interval: "weekly"
+  # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#enabling-dependabot-version-updates-for-actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 1
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/cancel-stale.yml
+++ b/.github/workflows/cancel-stale.yml
@@ -1,0 +1,21 @@
+# https://github.com/marketplace/actions/cancel-workflow-action#advanced-pull-requests-from-forks
+name: Cancel stale workflows
+on:
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_runbranchesbranches-ignore
+  workflow_run:
+    workflows:
+      - "Tests"
+    types:
+      - requested
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+      # TODO: switch back to styfle/cancel-workflow-action once the change get merged and released
+      - uses: hanabi1224/cancel-workflow-action@120898519f2940069cc6a070c4f9c3d6cc2e7ff8
+        with:
+          workflow_id: ${{ github.event.workflow.id }}
+          # https://github.com/styfle/cancel-workflow-action#advanced-all-but-latest
+          all_but_latest: true
+          ignore_branches_on_push: |
+            main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,13 @@
 name: Tests
 
-on: [pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,20 +7,32 @@ jobs:
     name: build-and-test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Install stable
-      run: rustup toolchain install stable
-    - name: Apt Dependencies
-      uses: nick-fields/retry@v2
-      with:
-        timeout_minutes: 5
-        max_attempts: 3
-        command: |
-          sudo make install-deps
-    - name: Build
-      run: cargo build --all
-    - name: Run tests
-      run: cargo test --all
+      - uses: actions/checkout@v1
+      - name: Apt Dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: |
+            sudo make install-deps
+      - name: Setup sccache
+        uses: hanabi1224/sccache-action@v1.2.0
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          release-name: v0.3.3
+          cache-key: ${{ runner.os }}-sccache-tests-${{ hashFiles('rust-toolchain.toml') }}
+          cache-update: ${{ github.event_name != 'pull_request' }}
+      - name: Build
+        run: cargo check --workspace
+        env:
+          CC: "sccache clang"
+          CXX: "sccache clang++"
+      - name: Run tests
+        run: cargo test --workspace
+        env:
+          CC: "sccache clang"
+          CXX: "sccache clang++"
 
   lint-all:
     name: All lint checks (lint audit spellcheck udeps)
@@ -43,10 +55,10 @@ jobs:
           RUSTFLAGS: "-Cstrip=symbols"
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
-        timeout-minutes: ${{ fromJSON(env.CACHE_TIMEOUT_MINUTES) }}
+        timeout-minutes: 5
         continue-on-error: true
         with:
-          release-name: v0.3.1
+          release-name: v0.3.3
           cache-key: ${{ runner.os }}-sccache-lints-${{ hashFiles('rust-toolchain.toml') }}
           cache-update: ${{ github.event_name != 'pull_request' }}
       - run: make lint-all


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Add `dependabot.yml`
- Add `cancel-stale.yml`
- Fix [CI workflow error](https://github.com/ChainSafe/fil-actor-states/actions/runs/4439393585/jobs/7791799816#step:12:1)
- Speed up `build-test` job by adding sccache action
- Replace `--all` with `--workspace` (--all          Alias for --workspace (deprecated))
- Run CI on push to main branch, otherwise sccache action could not fetch build cache for a new PR

```console
Error: .github/workflows/tests.yml (Line: 46, Col: [2](https://github.com/ChainSafe/fil-actor-states/actions/runs/4439393585/jobs/7791799816#step:12:2)6):
Error: .github/workflows/tests.yml (Line: 46, Col: 26): Unexpected value ''
Error: An error occurred when attempting to determine the step timeout.
Error: The template is not valid. .github/workflows/tests.yml (Line: [4](https://github.com/ChainSafe/fil-actor-states/actions/runs/4439393585/jobs/7791799816#step:12:4)6, Col: 26): Error reading JToken from JsonReader. Path '', line 0, position 0.,.github/workflows/tests.yml (Line: 46, Col: 26): Unexpected value ''
Post job cleanup.
```



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->