### PR TITLE
feat: remove opencl dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Apt Dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          command: |
-            sudo make install-deps
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         timeout-minutes: 5
@@ -53,7 +46,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 3
           command: |
-            sudo make install-deps
+            sudo apt-get update -y
             sudo apt-get install -y libclang-dev # required dep for cargo-spellcheck
       - uses: hanabi1224/cache-cargo-bin-action@v1.0.0
       - name: Install Lint tools
@@ -78,13 +71,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Apt Dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          command: |
-            sudo make install-deps
       - name: Setup sccache
         uses: hanabi1224/sccache-action@v1.2.0
         timeout-minutes: 5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,6 @@ dependencies = [
  "ec-gpu",
  "ec-gpu-gen",
  "ff",
- "fs2",
  "group",
  "log",
  "memmap2",
@@ -394,25 +393,6 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
-]
-
-[[package]]
-name = "cl-sys"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8573fa3ff8acd6c49e8e113296c54277e82376b96c6ca6307848632cce38e44"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cl3"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f2217b5993b54a819ac8e8569cc429702c8975a88d52c73e530f1f813576a3"
-dependencies = [
- "cl-sys",
- "libc",
 ]
 
 [[package]]
@@ -835,26 +815,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "ec-gpu"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,7 +837,6 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rayon",
- "rust-gpu-tools",
  "sha2 0.10.6",
  "thiserror",
  "yastl",
@@ -1718,7 +1677,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3303ea3c462ab949ab95b49f6e6d255d8d9396ebd4f1626ccb34c7037615aa8f"
 dependencies = [
  "blake2b_simd",
- "ec-gpu",
  "ff",
  "group",
  "lazy_static",
@@ -2750,8 +2708,6 @@ dependencies = [
  "blake2s_simd 0.5.11",
  "blstrs",
  "byteorder",
- "ec-gpu",
- "ec-gpu-gen",
  "ff",
  "fil_pasta_curves",
  "generic-array",
@@ -2903,16 +2859,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "opencl3"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931cc2ab3068142384dbdaba142681c11b315cf3b96c7a59e8480d062363387f"
-dependencies = [
- "cl3",
- "libc",
-]
 
 [[package]]
 name = "output_vt100"
@@ -3228,17 +3174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
-]
-
-[[package]]
 name = "regalloc2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,23 +3215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.6",
-]
-
-[[package]]
-name = "rust-gpu-tools"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2838e99bd4c9b3e6a963194440c6c5b66721d3f127625d709236ecaa1a730f"
-dependencies = [
- "dirs",
- "hex",
- "lazy_static",
- "log",
- "once_cell",
- "opencl3",
- "sha2 0.10.6",
- "temp-env",
- "thiserror",
 ]
 
 [[package]]
@@ -3737,15 +3655,6 @@ name = "target-lexicon"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
-
-[[package]]
-name = "temp-env"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45107136c2ddf8c4b87453c02294fd0adf41751796e81e8ba3f7fd951977ab57"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ blake2b_simd = "1.0"
 cid = { version = "0.8", default-features = false, features = ["std"] }
 frc42_dispatch = "3.0.0"
 frc46_token = "3.1.0"
-fvm = "~2.3"
+fvm = { version = "~2.3", default-features = false }
 fvm_ipld_amt = "0.5.1"
 fvm_ipld_bitfield = "0.5"
 fvm_ipld_blockstore = "0.1"

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,6 @@ install-lint-tools:
 	cargo install --locked cargo-spellcheck
 	cargo install --locked cargo-udeps
 
-install-deps:
-	apt-get update -y
-	apt-get install --no-install-recommends -y ocl-icd-opencl-dev
-
 # Lints with everything we have in our CI arsenal
 lint-all: lint audit udeps
 

--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ clean:
 	@cargo clean
 	@echo "Done cleaning."
 
-.PHONY: install-lint-tools install-deps lint-all audit udeps lint lint-clippy fmt clean
+.PHONY: install-lint-tools lint-all audit udeps lint lint-clippy fmt clean

--- a/fil_actor_interface/tests/dummy.rs
+++ b/fil_actor_interface/tests/dummy.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+mod tests {
+    /// This test is used to ensure dependencies on CI are sufficient, to avoid regressions in bringing opencl back
+    #[test]
+    fn ensure_no_missing_dll() {}
+}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Remove `opencl` dependency
- Cleanup CI `opencl` installation steps
- Regression tests

With this being merged, I think it's possible to remove `opencl` dependency from `forest` as well


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->