### PR TITLE
fix: pin fvm_shared to 3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,34 +1749,34 @@ dependencies = [
 
 [[package]]
 name = "frc42_dispatch"
-version = "3.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4dc594c941eba1d5a9474f595c6d0f9d752fa333b672755bbe7c23d30f64282"
+checksum = "a093747f6447d7528cf37b87b8ab9879c7417e960d2ea1ac523890eb3a924e2a"
 dependencies = [
  "frc42_hasher",
  "frc42_macros",
- "fvm_ipld_encoding 0.3.3",
- "fvm_sdk 3.0.0",
- "fvm_shared 3.1.0",
+ "fvm_ipld_encoding 0.2.3",
+ "fvm_sdk",
+ "fvm_shared 2.3.0",
  "thiserror",
 ]
 
 [[package]]
 name = "frc42_hasher"
-version = "1.4.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6caf7fa3028536d11b1ff94a63bd1d60926ff7366b25b2a94d07bd23190f459"
+checksum = "0cf52e60a67e9ad15cd4909ef8c8e45ab3744015dbb603efd8dfbdbfc7ce95b7"
 dependencies = [
- "fvm_sdk 3.0.0",
- "fvm_shared 3.1.0",
+ "fvm_sdk",
+ "fvm_shared 2.3.0",
  "thiserror",
 ]
 
 [[package]]
 name = "frc42_macros"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57201a8c3c26b41c4234a0f68b123ec2c33c958d31d09a3a780c345256e7928"
+checksum = "c343356c3652593452cc1cfe95535a915261342e2a4c13bb8388ca29b259a400"
 dependencies = [
  "blake2b_simd",
  "frc42_hasher",
@@ -1799,7 +1799,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_hamt 0.5.1",
- "fvm_sdk 2.2.0",
+ "fvm_sdk",
  "fvm_shared 2.3.0",
  "integer-encoding",
  "num-traits",
@@ -1881,7 +1881,7 @@ dependencies = [
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
- "fvm_sdk 2.2.0",
+ "fvm_sdk",
  "fvm_shared 2.3.0",
  "num-traits",
  "serde",
@@ -2030,21 +2030,6 @@ dependencies = [
  "cid",
  "fvm_ipld_encoding 0.2.3",
  "fvm_shared 2.3.0",
- "lazy_static",
- "log",
- "num-traits",
- "thiserror",
-]
-
-[[package]]
-name = "fvm_sdk"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fef17308967cceb1d22f05003d60adb0d5b9ba53e34ace4ae04701eb7e6af02"
-dependencies = [
- "cid",
- "fvm_ipld_encoding 0.3.3",
- "fvm_shared 3.1.0",
  "lazy_static",
  "log",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ fvm_ipld_blockstore = "0.1"
 fvm_ipld_encoding = "0.3"
 fvm_ipld_hamt = "0.6.1"
 fvm_shared = { version = "2", default-features = false }
-fvm_shared3 = { package = "fvm_shared", version = "3", default-features = false }
+fvm_shared3 = { package = "fvm_shared", version = "~3.1", default-features = false }
 getrandom = { version = "0.2.5" }
 hex = "0.4.3"
 hex-literal = "0.3.4"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- fvm_shared 3.2 has been released and is not strictly backwards compatible.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->