### PR TITLE
chore: upgrade rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-03-15"
+channel = "nightly-2023-04-19"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = []


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

- Upgrade rust toolchain to 1.71 nightly
- Fix clippy warnings / errors


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->