### PR TITLE
Pin fvm-shared to v2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ fvm_ipld_bitfield = "0.5"
 fvm_ipld_blockstore = "0.1"
 fvm_ipld_encoding = "0.3"
 fvm_ipld_hamt = "0.6.1"
-fvm_shared = { version = "2", default-features = false }
+fvm_shared = { version = "~2.3", default-features = false }
 fvm_shared3 = { package = "fvm_shared", version = "3.2", default-features = false }
 getrandom = { version = "0.2.5" }
 hex = "0.4.3"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Pin `fvm_shared` to v2.3 as v2.4 does not have backward compatibility



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->