### PR TITLE
feat: impl hamt_addr_key_to_key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +234,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdeb9ec472d588e539a818b2dee436825730da08ad0017c4b1a17676bdc8b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -555,12 +575,14 @@ version = "4.0.0"
 dependencies = [
  "anyhow",
  "cid",
+ "fil_actors_test_utils",
  "fvm_ipld_amt 0.5.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
  "fvm_shared 2.4.0",
  "fvm_shared 3.2.0",
+ "hex",
  "lazy_static",
  "multihash",
  "num",
@@ -568,13 +590,14 @@ dependencies = [
  "num-derive",
  "num-traits",
  "paste",
+ "pretty_assertions",
  "quickcheck",
  "quickcheck_macros",
  "serde",
  "serde_repr",
  "sha2",
  "thiserror",
- "toml 0.7.3",
+ "toml 0.7.4",
  "unsigned-varint",
 ]
 
@@ -875,6 +898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "674e86afc2ce02808d24f578296f105b13c23300e60e0eac331c4c1575beabb5"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "bitflags",
  "blake2b_simd",
  "cid",
@@ -887,6 +911,7 @@ dependencies = [
  "num-derive",
  "num-integer",
  "num-traits",
+ "quickcheck",
  "serde",
  "serde_tuple",
  "thiserror",
@@ -1108,6 +1133,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "quickcheck",
  "serde",
 ]
 
@@ -1442,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
 ]
@@ -1581,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1593,18 +1619,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
  "serde",

--- a/actors/market/src/v8/deal.rs
+++ b/actors/market/src/v8/deal.rs
@@ -207,7 +207,7 @@ mod tests {
 
         let cid_from_go = String::from_utf8_lossy(&app.stdout);
 
-        assert_eq!(proposal.cid()?.to_string(), cid_from_go.trim_end());
+        assert_eq!(proposal.cid()?.to_string(), cid_from_go);
 
         Ok(())
     }

--- a/fil_actors_shared/Cargo.toml
+++ b/fil_actors_shared/Cargo.toml
@@ -34,13 +34,18 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 unsigned-varint = { workspace = true }
 
+[dev-dependencies]
+fil_actors_test_utils = { workspace = true }
+fvm_shared3 = { workspace = true, features = ["arb"] }
+hex = { workspace = true }
+pretty_assertions = { workspace = true }
+quickcheck = { workspace = true }
+quickcheck_macros = { workspace = true }
+toml = { workspace = true }
+
 [features]
 default = []
 arb = ["quickcheck"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["num"]
-
-[dev-dependencies]
-quickcheck_macros = { workspace = true }
-toml = { workspace = true }

--- a/fil_actors_shared/src/v9/util/mod.rs
+++ b/fil_actors_shared/src/v9/util/mod.rs
@@ -1,6 +1,9 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fvm_ipld_hamt::BytesKey;
+use fvm_shared3::address::Address;
+
 pub use self::batch_return::BatchReturn;
 pub use self::batch_return::BatchReturnGen;
 pub use self::batch_return::FailCode;
@@ -16,3 +19,79 @@ mod mapmap;
 mod multimap;
 mod set;
 mod set_multimap;
+
+/// Converts address key to key, equivilent go code can be found at L54-L61 in
+/// <https://github.com/filecoin-project/go-state-types/blob/master/builtin/v9/migration/datacap.go#L54>
+pub fn hamt_addr_key_to_key(addr_key: BytesKey) -> anyhow::Result<BytesKey> {
+    let addr = Address::from_bytes(&addr_key)?;
+    Ok(addr.payload_bytes().into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{array::from_fn, process::Command};
+
+    use super::*;
+    use anyhow::*;
+    use fil_actors_test_utils::go_compat::{ensure_go_mod_prepared, go_compat_tests_dir};
+    use fvm_shared3::address::{Protocol, MAX_SUBADDRESS_LEN};
+    use pretty_assertions::assert_eq;
+    use quickcheck::Arbitrary;
+    use quickcheck_macros::quickcheck;
+
+    #[derive(Debug, Clone)]
+    struct AddressWrapper(Address);
+
+    impl Arbitrary for AddressWrapper {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            let mut addr = Address::arbitrary(g);
+            // HACK: Go code cannot parse uint greater than u63 upper bound
+            match addr.protocol() {
+                Protocol::ID => {
+                    addr = Address::new_id(u32::arbitrary(g) as _);
+                }
+                Protocol::Delegated => {
+                    let buffer: [u8; MAX_SUBADDRESS_LEN] = from_fn(|_| u8::arbitrary(g));
+                    let length = usize::arbitrary(g) % (MAX_SUBADDRESS_LEN + 1);
+                    addr =
+                        Address::new_delegated(u32::arbitrary(g) as _, &buffer[..length]).unwrap();
+                }
+                _ => {}
+            }
+
+            Self(addr)
+        }
+    }
+
+    #[quickcheck]
+    fn test_hamt_addr_key_to_key(addr: AddressWrapper) -> Result<()> {
+        ensure_go_mod_prepared();
+
+        let addr = addr.0;
+        let addr_key: BytesKey = addr.to_bytes().into();
+        let addr_key_hex = hex::encode(&addr_key.0);
+        let key = hamt_addr_key_to_key(addr_key)?;
+        let key_hex = hex::encode(&key.0);
+
+        let app = Command::new("go")
+            .args([
+                "run",
+                "shared/v9/test_addr_key_to_key.go",
+                "--addr",
+                addr_key_hex.as_str(),
+            ])
+            .current_dir(go_compat_tests_dir()?)
+            .output()?;
+
+        if !app.stderr.is_empty() {
+            println!("{}", String::from_utf8_lossy(&app.stderr));
+            anyhow::bail!("Fail to run go test");
+        }
+
+        let key_hex_from_go = String::from_utf8_lossy(&app.stdout);
+
+        assert_eq!(key_hex, key_hex_from_go);
+
+        Ok(())
+    }
+}

--- a/fil_actors_shared/src/v9/util/mod.rs
+++ b/fil_actors_shared/src/v9/util/mod.rs
@@ -22,8 +22,8 @@ mod set_multimap;
 
 /// Converts address key to key, equivilent go code can be found at L54-L61 in
 /// <https://github.com/filecoin-project/go-state-types/blob/master/builtin/v9/migration/datacap.go#L54>
-pub fn hamt_addr_key_to_key(addr_key: BytesKey) -> anyhow::Result<BytesKey> {
-    let addr = Address::from_bytes(&addr_key)?;
+pub fn hamt_addr_key_to_key(addr_key: &BytesKey) -> anyhow::Result<BytesKey> {
+    let addr = Address::from_bytes(addr_key)?;
     Ok(addr.payload_bytes().into())
 }
 
@@ -70,7 +70,7 @@ mod tests {
         let addr = addr.0;
         let addr_key: BytesKey = addr.to_bytes().into();
         let addr_key_hex = hex::encode(&addr_key.0);
-        let key = hamt_addr_key_to_key(addr_key)?;
+        let key = hamt_addr_key_to_key(&addr_key)?;
         let key_hex = hex::encode(&key.0);
 
         let app = Command::new("go")

--- a/go_compat/go.mod
+++ b/go_compat/go.mod
@@ -2,10 +2,12 @@ module test/v2
 
 go 1.19
 
-require github.com/filecoin-project/go-state-types v0.11.1
+require (
+	github.com/filecoin-project/go-address v1.1.0
+	github.com/filecoin-project/go-state-types v0.11.1
+)
 
 require (
-	github.com/filecoin-project/go-address v1.1.0 // indirect
 	github.com/filecoin-project/go-amt-ipld/v4 v4.0.0 // indirect
 	github.com/filecoin-project/go-bitfield v0.2.4 // indirect
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.1.0 // indirect

--- a/go_compat/tests/actors/market/v8/test_deal_proposal_cid.go
+++ b/go_compat/tests/actors/market/v8/test_deal_proposal_cid.go
@@ -34,5 +34,5 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Println(cid)
+	fmt.Print(cid)
 }

--- a/go_compat/tests/shared/v9/test_addr_key_to_key.go
+++ b/go_compat/tests/shared/v9/test_addr_key_to_key.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+)
+
+func main() {
+	var addr string
+
+	flag.StringVar(&addr, "addr", "", "address bytes in hex")
+
+	flag.Parse()
+
+	addrBytes, err := hex.DecodeString(addr)
+	if err != nil {
+		panic(err)
+	}
+
+	a, err := address.NewFromBytes(addrBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	key := abi.IdAddrKey(a)
+
+	fmt.Print(hex.EncodeToString([]byte(key.Key())))
+}


### PR DESCRIPTION
**Summary of changes**
As part of https://github.com/ChainSafe/forest/issues/2801

Changes introduced in this pull request:
- impl `fn hamt_addr_key_to_key` which is used by nv17 migrations, see [code](https://github.com/filecoin-project/go-state-types/blob/master/builtin/v9/migration/datacap.go#L54)
- go compat tests



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->