### PR TITLE
Remove forest specific dependencies from init v0 actor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,37 +36,9 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
-
-[[package]]
-name = "async-recursion"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.18",
-]
 
 [[package]]
 name = "autocfg"
@@ -88,24 +60,13 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "constant_time_eq 0.1.5",
-]
-
-[[package]]
-name = "blake2b_simd"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.2",
- "constant_time_eq 0.2.5",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -115,8 +76,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.2",
- "constant_time_eq 0.2.5",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -126,19 +87,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.2",
+ "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.2.5",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -179,34 +131,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cid"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff0e3bc0b6446b3f9663c1a6aba6ef06c5aeaa1bc92bd18077be337198ab9768"
-dependencies = [
- "multibase 0.8.0",
- "multihash 0.13.2",
- "unsigned-varint 0.5.1",
-]
-
-[[package]]
-name = "cid"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ed9c8b2d17acb8110c46f1da5bf4a696d745e1474a16db0cd2b49cd0249bf2"
 dependencies = [
  "core2",
- "multibase 0.9.1",
- "multihash 0.16.3",
+ "multibase",
+ "multihash",
  "serde",
  "serde_bytes",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -258,16 +193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cs_serde_cbor"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7b77425566bdb3932243a292a4b072e1e34fb93aba95926f8d4a3b6ce542c5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,20 +236,11 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
 ]
 
@@ -421,7 +337,7 @@ dependencies = [
 name = "fil_actor_evm_state"
 version = "4.0.0"
 dependencies = [
- "cid 0.8.6",
+ "cid",
  "fil_actor_evm_shared_state",
  "frc42_dispatch",
  "fvm_ipld_encoding 0.3.3",
@@ -437,21 +353,14 @@ name = "fil_actor_init_state"
 version = "4.0.0"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fil_actors_shared",
- "forest_address",
- "forest_cid",
- "forest_encoding",
- "forest_vm",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
  "fvm_shared 2.4.0",
  "fvm_shared 3.3.1",
- "ipld_blockstore",
- "ipld_hamt",
- "multihash 0.16.3",
  "num-derive",
  "num-traits",
  "serde",
@@ -462,7 +371,7 @@ name = "fil_actor_interface"
 version = "4.0.0"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fil_actor_account_state",
  "fil_actor_cron_state",
  "fil_actor_datacap_state",
@@ -481,6 +390,7 @@ dependencies = [
  "fvm_shared 2.4.0",
  "fvm_shared 3.3.1",
  "lazy_static",
+ "multihash",
  "num",
  "regex",
  "serde",
@@ -493,7 +403,7 @@ name = "fil_actor_market_state"
 version = "4.0.0"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fil_actor_verifreg_state",
  "fil_actors_shared",
  "fil_actors_test_utils",
@@ -506,7 +416,7 @@ dependencies = [
  "fvm_shared 3.3.1",
  "hex",
  "libipld-core 0.14.0",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-derive",
  "num-traits",
  "pretty_assertions",
@@ -520,7 +430,7 @@ name = "fil_actor_miner_state"
 version = "4.0.0"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fil_actor_verifreg_state",
  "fil_actors_shared",
  "fil_actors_test_utils",
@@ -535,15 +445,15 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
- "multihash 0.16.3",
- "num-bigint 0.4.3",
+ "multihash",
+ "num-bigint",
  "num-derive",
  "num-traits",
  "pretty_assertions",
  "quickcheck",
  "quickcheck_macros",
  "serde",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -551,7 +461,7 @@ name = "fil_actor_multisig_state"
 version = "4.0.0"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fil_actors_shared",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
@@ -560,7 +470,7 @@ dependencies = [
  "fvm_shared 2.4.0",
  "fvm_shared 3.3.1",
  "indexmap",
- "integer-encoding 3.0.4",
+ "integer-encoding",
  "num-derive",
  "num-traits",
  "serde",
@@ -570,7 +480,7 @@ dependencies = [
 name = "fil_actor_paych_state"
 version = "4.0.0"
 dependencies = [
- "cid 0.8.6",
+ "cid",
  "fil_actors_shared",
  "frc42_dispatch",
  "fvm_ipld_encoding 0.3.3",
@@ -586,7 +496,7 @@ name = "fil_actor_power_state"
 version = "4.0.0"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fil_actors_shared",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
@@ -594,7 +504,7 @@ dependencies = [
  "fvm_ipld_hamt 0.6.1",
  "fvm_shared 2.4.0",
  "fvm_shared 3.3.1",
- "integer-encoding 3.0.4",
+ "integer-encoding",
  "lazy_static",
  "num-derive",
  "num-traits",
@@ -619,7 +529,7 @@ dependencies = [
 name = "fil_actor_system_state"
 version = "4.0.0"
 dependencies = [
- "cid 0.8.6",
+ "cid",
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared 2.4.0",
  "num-derive",
@@ -632,7 +542,7 @@ name = "fil_actor_verifreg_state"
 version = "4.0.0"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fil_actors_shared",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
@@ -649,7 +559,7 @@ name = "fil_actors_shared"
 version = "4.0.0"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fvm_ipld_amt 0.5.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
@@ -657,9 +567,9 @@ dependencies = [
  "fvm_shared 2.4.0",
  "fvm_shared 3.3.1",
  "lazy_static",
- "multihash 0.16.3",
+ "multihash",
  "num",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-derive",
  "num-traits",
  "paste",
@@ -667,10 +577,10 @@ dependencies = [
  "quickcheck_macros",
  "serde",
  "serde_repr",
- "sha2 0.10.6",
+ "sha2",
  "thiserror",
  "toml 0.7.4",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -679,81 +589,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "lazy_static",
- "parking_lot 0.12.1",
-]
-
-[[package]]
-name = "forest_address"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36b7dbc8805f7d93e4a3c63a5be26dd521d3a62b20cc9453eaf722022d7f8ee"
-dependencies = [
- "data-encoding",
- "data-encoding-macro",
- "forest_encoding",
- "leb128",
- "log",
- "num-derive",
- "num-traits",
- "once_cell",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "forest_bigint"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559d63f33ef82723a75b2b25703b31c50a55d2950ead45e239e49b19aeefd1e7"
-dependencies = [
- "cs_serde_bytes",
- "num-bigint 0.3.3",
- "num-integer",
- "serde",
-]
-
-[[package]]
-name = "forest_cid"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1a935d7f977a7debbc507de2ab7990b834d85e94c819e5268b1adaefd7d434"
-dependencies = [
- "cid 0.6.1",
- "cs_serde_bytes",
- "cs_serde_cbor",
- "forest_json_utils",
- "generic-array",
- "integer-encoding 2.1.3",
- "multibase 0.9.1",
- "multihash 0.13.2",
- "serde",
-]
-
-[[package]]
-name = "forest_db"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637464246b3f5554e6d7678cf05d8d76a5cbefe3324cd8c5c5a24c62c379af46"
-dependencies = [
- "forest_encoding",
- "parking_lot 0.11.2",
- "thiserror",
-]
-
-[[package]]
-name = "forest_encoding"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c8339c6dc1741c3144ba06cfb0512a2e858bd603be97bff24bf630d91cce7d"
-dependencies = [
- "blake2b_simd 0.5.11",
- "cs_serde_bytes",
- "cs_serde_cbor",
- "forest_cid",
- "serde",
- "serde_repr",
- "serde_tuple",
- "thiserror",
+ "parking_lot",
 ]
 
 [[package]]
@@ -764,47 +600,6 @@ checksum = "edb061ad769411763a5d6ae39d596696657472b25a66387fbb0ba8c133bb6575"
 dependencies = [
  "cs_serde_bytes",
  "serde",
-]
-
-[[package]]
-name = "forest_ipld"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a7f6dd22f807768d16d299594f3c4c806d916a1e7461ac1c9bbdd93159272cc"
-dependencies = [
- "async-recursion",
- "async-trait",
- "forest_cid",
- "forest_encoding",
- "indexmap",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "forest_json_utils"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da39ba6848c04b22e70520a1339f04f304502a0ebfd4526ea8a566452ea62a8"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "forest_vm"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba5f1b93b15568dc4d96b333c73a1949bfba11ce539a6b5495c02e9a9d9190a"
-dependencies = [
- "forest_address",
- "forest_bigint",
- "forest_cid",
- "forest_encoding",
- "lazy_static",
- "num-derive",
- "num-traits",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -838,7 +633,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c343356c3652593452cc1cfe95535a915261342e2a4c13bb8388ca29b259a400"
 dependencies = [
- "blake2b_simd 1.0.1",
+ "blake2b_simd",
  "frc42_hasher",
  "proc-macro2",
  "quote",
@@ -852,7 +647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112bdb7d37e58715087146b19465f59374e8cffd81561a8d20dbdb1eb2c75fbe"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "frc42_dispatch",
  "fvm_actor_utils",
  "fvm_ipld_amt 0.4.2",
@@ -861,7 +656,7 @@ dependencies = [
  "fvm_ipld_hamt 0.5.1",
  "fvm_sdk",
  "fvm_shared 2.4.0",
- "integer-encoding 3.0.4",
+ "integer-encoding",
  "num-traits",
  "serde",
  "serde_tuple",
@@ -875,7 +670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a11cab1852eb6f381cc11ebcfa6b2c84d3df5b5603ab6c79d6b02761718da77"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "frc42_dispatch",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
@@ -895,7 +690,7 @@ checksum = "48d09e5aa7de45452676d18fcb70b750acd65faae7a4fe18fe784b4c85f869fb"
 dependencies = [
  "ahash",
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "itertools",
@@ -911,7 +706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e84f16d6927ce342ef86bd20fcc2d5bd498ed33ae6d7a22fea7a1b453488ec88"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "itertools",
@@ -929,7 +724,7 @@ dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "serde",
  "thiserror",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -939,8 +734,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fee8c75be2b58943e1a9755802d34d4c3934f6ea151b6be192ff98f644e515bd"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
- "multihash 0.16.3",
+ "cid",
+ "multihash",
 ]
 
 [[package]]
@@ -950,10 +745,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa1ff5ba581625ab38cf2829fbd04ac232c6277466fdbe0270b42dcb976902d5"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "cs_serde_bytes",
  "fvm_ipld_blockstore",
- "multihash 0.16.3",
+ "multihash",
  "serde",
  "serde_ipld_dagcbor",
  "serde_repr",
@@ -968,9 +763,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0816a2a6df4853de08a723d261110d56a121aa313bc570fe9d248f0a4bc5288"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "fvm_ipld_blockstore",
- "multihash 0.16.3",
+ "multihash",
  "serde",
  "serde_ipld_dagcbor",
  "serde_repr",
@@ -986,16 +781,16 @@ checksum = "65b5c939897aa1bfd63e7cb9c458ba10689371af3278ff20d66c6f8ca152c6c0"
 dependencies = [
  "anyhow",
  "byteorder",
- "cid 0.8.6",
+ "cid",
  "cs_serde_bytes",
  "forest_hash_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "libipld-core 0.13.1",
- "multihash 0.16.3",
+ "multihash",
  "once_cell",
  "serde",
- "sha2 0.10.6",
+ "sha2",
  "thiserror",
 ]
 
@@ -1007,15 +802,15 @@ checksum = "0c942494dde990aeac314311bde34c787be99cab7d0836397a75556cbaa2c3e7"
 dependencies = [
  "anyhow",
  "byteorder",
- "cid 0.8.6",
+ "cid",
  "forest_hash_utils",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "libipld-core 0.14.0",
- "multihash 0.16.3",
+ "multihash",
  "once_cell",
  "serde",
- "sha2 0.10.6",
+ "sha2",
  "thiserror",
 ]
 
@@ -1025,7 +820,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb46d7b26e1609de1a3b7470cbd190d78f2d01fdf1b317f741bdd3ac8f59825e"
 dependencies = [
- "cid 0.8.6",
+ "cid",
  "fvm_ipld_encoding 0.2.3",
  "fvm_shared 2.4.0",
  "lazy_static",
@@ -1041,9 +836,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05eebc49ba13d8aae14c396e4d700c83361eca673cae9c0bfc69cb6e754bd468"
 dependencies = [
  "anyhow",
- "blake2b_simd 1.0.1",
+ "blake2b_simd",
  "byteorder",
- "cid 0.8.6",
+ "cid",
  "cs_serde_bytes",
  "data-encoding",
  "data-encoding-macro",
@@ -1051,8 +846,8 @@ dependencies = [
  "fvm_ipld_encoding 0.2.3",
  "lazy_static",
  "log",
- "multihash 0.16.3",
- "num-bigint 0.4.3",
+ "multihash",
+ "num-bigint",
  "num-derive",
  "num-integer",
  "num-traits",
@@ -1060,7 +855,7 @@ dependencies = [
  "serde_repr",
  "serde_tuple",
  "thiserror",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -1071,21 +866,21 @@ checksum = "2ad76f06f7d59215844900d018ffc5c863a370afab9c329bae290305722f8d60"
 dependencies = [
  "anyhow",
  "bitflags",
- "blake2b_simd 1.0.1",
- "cid 0.8.6",
+ "blake2b_simd",
+ "cid",
  "data-encoding",
  "data-encoding-macro",
  "fvm_ipld_encoding 0.3.3",
  "lazy_static",
- "multihash 0.16.3",
- "num-bigint 0.4.3",
+ "multihash",
+ "num-bigint",
  "num-derive",
  "num-integer",
  "num-traits",
  "serde",
  "serde_tuple",
  "thiserror",
- "unsigned-varint 0.7.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -1108,12 +903,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "half"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -1145,56 +934,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "integer-encoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27df786dcc3a75ccd134f83ece166af0a1e5785d52b12b7375d0d063e1d5c47"
-
-[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
-name = "ipld_blockstore"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00297ec82ec490ef38b5f703413d7fb8b3bdf0e64690a459662a1898afcc11b"
-dependencies = [
- "forest_cid",
- "forest_db",
- "forest_encoding",
-]
-
-[[package]]
-name = "ipld_hamt"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3aae17f7905e9a426094aa3fc9f645d0a2028959e6fedbf4840f88c4d9a1a0"
-dependencies = [
- "byteorder",
- "cs_serde_bytes",
- "forest_cid",
- "forest_db",
- "forest_encoding",
- "forest_hash_utils",
- "forest_ipld",
- "ipld_blockstore",
- "lazycell",
- "serde",
- "sha2 0.9.9",
- "thiserror",
-]
 
 [[package]]
 name = "itertools"
@@ -1227,18 +970,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "leb128"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
 name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,10 +982,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdd758764f9680a818af33c31db733eb7c45224715d8816b9dcf0548c75f7c5"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "core2",
- "multibase 0.9.1",
- "multihash 0.16.3",
+ "multibase",
+ "multihash",
  "serde",
  "thiserror",
 ]
@@ -1266,10 +997,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d44790246ec6b7314cba745992c23d479d018073e66d49ae40ae1b64e5dd8eb5"
 dependencies = [
  "anyhow",
- "cid 0.8.6",
+ "cid",
  "core2",
- "multibase 0.9.1",
- "multihash 0.16.3",
+ "multibase",
+ "multihash",
  "serde",
  "thiserror",
 ]
@@ -1298,17 +1029,6 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "multibase"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78c60039650ff12e140ae867ef5299a58e19dded4d334c849dc7177083667e2"
-dependencies = [
- "base-x",
- "data-encoding",
- "data-encoding-macro",
-]
-
-[[package]]
-name = "multibase"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
@@ -1320,48 +1040,22 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
-dependencies = [
- "blake2b_simd 0.5.11",
- "generic-array",
- "multihash-derive 0.7.2",
- "unsigned-varint 0.5.1",
-]
-
-[[package]]
-name = "multihash"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
 dependencies = [
- "blake2b_simd 1.0.1",
+ "blake2b_simd",
  "blake2s_simd",
  "blake3",
  "core2",
- "digest 0.10.7",
- "multihash-derive 0.8.1",
+ "digest",
+ "multihash-derive",
  "ripemd",
  "serde",
  "serde-big-array",
- "sha2 0.10.6",
+ "sha2",
  "sha3",
- "unsigned-varint 0.7.1",
-]
-
-[[package]]
-name = "multihash-derive"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
-dependencies = [
- "proc-macro-crate",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -1384,22 +1078,11 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -1463,7 +1146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -1484,12 +1167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,37 +1177,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1688,7 +1340,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1748,7 +1400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e23de7a4a18dff77ab9531f279a882500b8cf3549fde044d4e10481b411f1e"
 dependencies = [
  "cbor4ii",
- "cid 0.8.6",
+ "cid",
  "scopeguard",
  "serde",
 ]
@@ -1820,26 +1472,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1848,7 +1487,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 
@@ -1996,12 +1635,6 @@ name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 
 [[package]]
 name = "unsigned-varint"

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -25,12 +25,3 @@ fvm_shared3 = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-
-# V0 dependencies
-address = { package = "forest_address", version = "0.3" }
-encoding = { package = "forest_encoding", version = "0.2.1" }
-forest_cid = { version = "0.3", features = ["cbor"] }
-ipld_blockstore = "0.1"
-ipld_hamt = { version = "0.1", features = ["go-interop"] }
-multihash = { version = "0.16.3", features = ["identity"] }
-vm = { package = "forest_vm", version = "0.3" }

--- a/actors/init/src/v0/mod.rs
+++ b/actors/init/src/v0/mod.rs
@@ -1,8 +1,8 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use fvm_shared::METHOD_CONSTRUCTOR;
 use num_derive::FromPrimitive;
-use vm::METHOD_CONSTRUCTOR;
 
 pub use self::state::State;
 pub use self::types::*;

--- a/actors/init/src/v0/state.rs
+++ b/actors/init/src/v0/state.rs
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use cid::Cid;
-use fil_actors_shared::v8::{make_map_with_root, FIRST_NON_SINGLETON_ADDR};
-use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
-use fvm_ipld_hamt::Error as HamtError;
-use fvm_shared::address::{Address, Protocol};
 use fvm_shared::ActorID;
-use std::error::Error as StdError;
+
+/// Defines first available ID address after builtin actors
+pub const FIRST_NON_SINGLETON_ADDR: ActorID = 100;
 
 /// State is reponsible for creating
 #[derive(Debug, Serialize_tuple, Deserialize_tuple)]
@@ -25,46 +23,5 @@ impl State {
             next_id: FIRST_NON_SINGLETON_ADDR,
             network_name,
         }
-    }
-
-    /// Allocates a new ID address and stores a mapping of the argument address to it.
-    /// Returns the newly-allocated address.
-    pub fn map_address_to_new_id<BS: Blockstore>(
-        &mut self,
-        store: &BS,
-        addr: &Address,
-    ) -> Result<Address, HamtError> {
-        let id = self.next_id;
-        self.next_id += 1;
-
-        let mut map = make_map_with_root(&self.address_map, store)?;
-        map.set(addr.to_bytes().into(), id)?;
-        self.address_map = map.flush()?;
-
-        Ok(Address::new_id(id))
-    }
-
-    /// ResolveAddress resolves an address to an ID-address, if possible.
-    /// If the provided address is an ID address, it is returned as-is.
-    /// This means that mapped ID-addresses (which should only appear as values, not keys) and
-    /// singleton actor addresses (which are not in the map) pass through unchanged.
-    ///
-    /// Returns an ID-address and `true` if the address was already an ID-address or was resolved
-    /// in the mapping.
-    /// Returns an undefined address and `false` if the address was not an ID-address and not found
-    /// in the mapping.
-    /// Returns an error only if state was inconsistent.
-    pub fn resolve_address<BS: Blockstore>(
-        &self,
-        store: &BS,
-        addr: &Address,
-    ) -> Result<Option<Address>, Box<dyn StdError>> {
-        if addr.protocol() == Protocol::ID {
-            return Ok(Some(*addr));
-        }
-
-        let map = make_map_with_root(&self.address_map, store)?;
-
-        Ok(map.get(&addr.to_bytes())?.copied().map(Address::new_id))
     }
 }

--- a/actors/init/src/v0/types.rs
+++ b/actors/init/src/v0/types.rs
@@ -1,10 +1,10 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use address::Address;
-use encoding::{tuple::*, Cbor};
-use forest_cid::Cid;
-use vm::Serialized;
+use cid::Cid;
+use fvm_ipld_encoding::tuple::*;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::Address;
 
 /// Init actor Constructor parameters
 #[derive(Serialize_tuple, Deserialize_tuple)]
@@ -16,7 +16,7 @@ pub struct ConstructorParams {
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ExecParams {
     pub code_cid: Cid,
-    pub constructor_params: Serialized,
+    pub constructor_params: RawBytes,
 }
 
 /// Init actor Exec Return value
@@ -27,5 +27,3 @@ pub struct ExecReturn {
     /// Reorg safe address for actor
     pub robust_address: Address,
 }
-
-impl Cbor for ExecReturn {}

--- a/fil_actor_interface/Cargo.toml
+++ b/fil_actor_interface/Cargo.toml
@@ -29,6 +29,7 @@ fvm_ipld_encoding.workspace = true
 fvm_shared = { workspace = true }
 fvm_shared3 = { workspace = true }
 lazy_static.workspace = true
+multihash = { workspace = true, features = ["identity"] }
 num.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/fil_actor_interface/src/builtin/known_cids.rs
+++ b/fil_actor_interface/src/builtin/known_cids.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::r#mod::cid_serde;
-use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
+use multihash::{Code, MultihashDigest};
 use serde::{Deserialize, Serialize};
 
 const RAW: u64 = 0x55;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Use fvm crates instead of forest crates in init v0 actor



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #129 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->