### PR TITLE
Fix no space left issue on publishing crates

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -29,4 +29,5 @@ for crate in "${crates[@]}"; do
 
     # Publish to crates.io
     cargo publish --manifest-path "$crate_manifest" --token "$CRATES_IO_TOKEN"
+    cargo clean --manifest-path "$crate_manifest"
 done


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

When running `publish.sh` on `ubuntu-latest` we end up using all disk space currently on that machine.
- Added a `cargo clean` after every crate is published



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->