### PR TITLE
chore: revert submodule to `main` branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "forest"]
 	path = forest
 	url = https://github.com/ChainSafe/forest.git
-	branch = "lemmih/fvm-3.5-upgrade"
+	branch = "main"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- use `main` in the forest submodule.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->