### PR TITLE
fix: do not assign everyone to review every pr

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-# CODEOWNERS: https://help.github.com/articles/about-codeowners/
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# they will be requested for review when someone opens a pull request.
-*       @hanabi1224 @elmattic @lemmih @LesnyRumcajs @jdjaustin @tyshko5 @sudo-shashank @creativcoder


### PR DESCRIPTION
We've got a new review assignment system - two per PR, which is out-of-repo.