### PR TITLE
use fuzzy instead of buildjet

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
   forest-sync-check:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Release') }}
     name: forest calibnet sync check
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: fuzzy
     steps:
       - uses: actions/checkout@v4
       - name: Setup sccache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,6 @@ on:
       - main
 
 env:
-  SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   # https://github.com/BurntSushi/quickcheck/blob/master/src/tester.rs#L21
   QUICKCHECK_TESTS: 10

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,9 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Release') }}
     name: forest calibnet sync check
     runs-on: fuzzy
+    env:
+      # Use local filesystem of `fuzzy` for caching
+      SCCACHE_GHA_ENABLED: "false"
     steps:
       - uses: actions/checkout@v4
       - name: Setup sccache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ on:
       - main
 
 env:
+  SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   # https://github.com/BurntSushi/quickcheck/blob/master/src/tester.rs#L21
   QUICKCHECK_TESTS: 10


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- use `fuzzy` instead of `buildjet`. It shouldn't require much of its resources and frees us completely from `buildjet` bills.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->