### PR TITLE
add merge group to workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ concurrency:
 
 on:
   workflow_dispatch:
+  merge_group:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- we're missing `merge_group` in workflows. Without it, the jobs in the merge queue are not being run.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->