### PR TITLE
Revert "use fuzzy instead of buildjet (#176)"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,10 +49,7 @@ jobs:
   forest-sync-check:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Release') }}
     name: forest calibnet sync check
-    runs-on: fuzzy
-    env:
-      # Use local filesystem of `fuzzy` for caching
-      SCCACHE_GHA_ENABLED: "false"
+    runs-on: buildjet-8vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v4
       - name: Setup sccache


### PR DESCRIPTION
This reverts commit 35350701d65e1d6e8c2fde3001b5b443032d6720.

**Summary of changes**
Changes introduced in this pull request:
- there seems to be a wild race on the Cargo file with the `fuzzy` as worker. The file is mixed with Forest Cargo file. [Cargo.toml](https://github.com/ChainSafe/fil-actor-states/files/12892836/Cargo.toml.txt). Full error: https://github.com/ChainSafe/fil-actor-states/actions/runs/6506927548/job/17674105715?pr=183



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->

