### PR TITLE
Derive Clone for SectorOnChainInfo data type

### DIFF
--- a/fil_actor_interface/src/builtin/miner/mod.rs
+++ b/fil_actor_interface/src/builtin/miner/mod.rs
@@ -543,7 +543,7 @@ impl Partition<'_> {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct SectorOnChainInfo {
     pub sector_number: SectorNumber,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Derive clone trait for `SectorOnChainInfo` required for `StateSectorGetInfo` rpc



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->