### PR TITLE
New methods for Miner Deadline

### DIFF
--- a/fil_actor_interface/src/builtin/miner/mod.rs
+++ b/fil_actor_interface/src/builtin/miner/mod.rs
@@ -492,6 +492,28 @@ impl Deadline {
             }),
         }
     }
+
+    /// Returns number of partitions posted
+    pub fn partitions_posted(&self) -> BitField {
+        match self {
+            Deadline::V8(dl) => dl.partitions_posted.clone(),
+            Deadline::V9(dl) => dl.partitions_posted.clone(),
+            Deadline::V10(dl) => dl.partitions_posted.clone(),
+            Deadline::V11(dl) => dl.partitions_posted.clone(),
+            Deadline::V12(dl) => dl.partitions_posted.clone(),
+        }
+    }
+
+    /// Returns disputable proof count of the deadline
+    pub fn disputable_proof_count<BS: Blockstore>(&self, store: &BS) -> anyhow::Result<u64> {
+        match self {
+            Deadline::V8(dl) => Ok(dl.optimistic_proofs_snapshot_amt(store)?.count()),
+            Deadline::V9(dl) => Ok(dl.optimistic_proofs_snapshot_amt(store)?.count()),
+            Deadline::V10(dl) => Ok(dl.optimistic_proofs_snapshot_amt(store)?.count()),
+            Deadline::V11(dl) => Ok(dl.optimistic_proofs_snapshot_amt(store)?.count()),
+            Deadline::V12(dl) => Ok(dl.optimistic_proofs_snapshot_amt(store)?.count()),
+        }
+    }
 }
 
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Added 2 new methods `partitions_posted` and `disputable_proof_count` required for `Filecoin.StateMinerDeadlines`


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->

Part of https://github.com/ChainSafe/forest/pull/3761


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->