### PR TITLE
feat: make `DeadlineInfo` available in the miner interface

### DIFF
--- a/actors/miner/src/v10/deadline_info.rs
+++ b/actors/miner/src/v10/deadline_info.rs
@@ -28,14 +28,14 @@ pub struct DeadlineInfo {
 
     // Protocol parameters (This is intentionally included in the JSON response for deadlines)
     #[serde(rename = "WPoStPeriodDeadlines")]
-    w_post_period_deadlines: u64,
+    pub w_post_period_deadlines: u64,
     #[serde(rename = "WPoStProvingPeriod")]
-    w_post_proving_period: ChainEpoch,
+    pub w_post_proving_period: ChainEpoch,
     #[serde(rename = "WPoStChallengeWindow")]
-    w_post_challenge_window: ChainEpoch,
+    pub w_post_challenge_window: ChainEpoch,
     #[serde(rename = "WPoStChallengeLookback")]
-    w_post_challenge_lookback: ChainEpoch,
-    fault_declaration_cutoff: ChainEpoch,
+    pub w_post_challenge_lookback: ChainEpoch,
+    pub fault_declaration_cutoff: ChainEpoch,
 }
 
 impl DeadlineInfo {

--- a/actors/miner/src/v11/deadline_info.rs
+++ b/actors/miner/src/v11/deadline_info.rs
@@ -28,14 +28,14 @@ pub struct DeadlineInfo {
 
     // Protocol parameters (This is intentionally included in the JSON response for deadlines)
     #[serde(rename = "WPoStPeriodDeadlines")]
-    w_post_period_deadlines: u64,
+    pub w_post_period_deadlines: u64,
     #[serde(rename = "WPoStProvingPeriod")]
-    w_post_proving_period: ChainEpoch,
+    pub w_post_proving_period: ChainEpoch,
     #[serde(rename = "WPoStChallengeWindow")]
-    w_post_challenge_window: ChainEpoch,
+    pub w_post_challenge_window: ChainEpoch,
     #[serde(rename = "WPoStChallengeLookback")]
-    w_post_challenge_lookback: ChainEpoch,
-    fault_declaration_cutoff: ChainEpoch,
+    pub w_post_challenge_lookback: ChainEpoch,
+    pub fault_declaration_cutoff: ChainEpoch,
 }
 
 impl DeadlineInfo {

--- a/actors/miner/src/v12/deadline_info.rs
+++ b/actors/miner/src/v12/deadline_info.rs
@@ -28,14 +28,14 @@ pub struct DeadlineInfo {
 
     // Protocol parameters (This is intentionally included in the JSON response for deadlines)
     #[serde(rename = "WPoStPeriodDeadlines")]
-    w_post_period_deadlines: u64,
+    pub w_post_period_deadlines: u64,
     #[serde(rename = "WPoStProvingPeriod")]
-    w_post_proving_period: ChainEpoch,
+    pub w_post_proving_period: ChainEpoch,
     #[serde(rename = "WPoStChallengeWindow")]
-    w_post_challenge_window: ChainEpoch,
+    pub w_post_challenge_window: ChainEpoch,
     #[serde(rename = "WPoStChallengeLookback")]
-    w_post_challenge_lookback: ChainEpoch,
-    fault_declaration_cutoff: ChainEpoch,
+    pub w_post_challenge_lookback: ChainEpoch,
+    pub fault_declaration_cutoff: ChainEpoch,
 }
 
 impl DeadlineInfo {

--- a/actors/miner/src/v8/deadline_info.rs
+++ b/actors/miner/src/v8/deadline_info.rs
@@ -28,14 +28,14 @@ pub struct DeadlineInfo {
 
     // Protocol parameters (This is intentionally included in the JSON response for deadlines)
     #[serde(rename = "WPoStPeriodDeadlines")]
-    w_post_period_deadlines: u64,
+    pub w_post_period_deadlines: u64,
     #[serde(rename = "WPoStProvingPeriod")]
-    w_post_proving_period: ChainEpoch,
+    pub w_post_proving_period: ChainEpoch,
     #[serde(rename = "WPoStChallengeWindow")]
-    w_post_challenge_window: ChainEpoch,
+    pub w_post_challenge_window: ChainEpoch,
     #[serde(rename = "WPoStChallengeLookback")]
-    w_post_challenge_lookback: ChainEpoch,
-    fault_declaration_cutoff: ChainEpoch,
+    pub w_post_challenge_lookback: ChainEpoch,
+    pub fault_declaration_cutoff: ChainEpoch,
 }
 
 impl DeadlineInfo {

--- a/actors/miner/src/v9/deadline_info.rs
+++ b/actors/miner/src/v9/deadline_info.rs
@@ -28,14 +28,14 @@ pub struct DeadlineInfo {
 
     // Protocol parameters (This is intentionally included in the JSON response for deadlines)
     #[serde(rename = "WPoStPeriodDeadlines")]
-    w_post_period_deadlines: u64,
+    pub w_post_period_deadlines: u64,
     #[serde(rename = "WPoStProvingPeriod")]
-    w_post_proving_period: ChainEpoch,
+    pub w_post_proving_period: ChainEpoch,
     #[serde(rename = "WPoStChallengeWindow")]
-    w_post_challenge_window: ChainEpoch,
+    pub w_post_challenge_window: ChainEpoch,
     #[serde(rename = "WPoStChallengeLookback")]
-    w_post_challenge_lookback: ChainEpoch,
-    fault_declaration_cutoff: ChainEpoch,
+    pub w_post_challenge_lookback: ChainEpoch,
+    pub fault_declaration_cutoff: ChainEpoch,
 }
 
 impl DeadlineInfo {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Expose a standardized interface to `DeadlineInfo` from the miner actor.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->