### PR TITLE
Add a `Partition::recovering_sectors` method

### DIFF
--- a/fil_actor_interface/src/builtin/miner/mod.rs
+++ b/fil_actor_interface/src/builtin/miner/mod.rs
@@ -657,6 +657,15 @@ impl Partition<'_> {
             Partition::V12(dl) => dl.active_sectors(),
         }
     }
+    pub fn recovering_sectors(&self) -> &BitField {
+        match self {
+            Partition::V8(dl) => &dl.recoveries,
+            Partition::V9(dl) => &dl.recoveries,
+            Partition::V10(dl) => &dl.recoveries,
+            Partition::V11(dl) => &dl.recoveries,
+            Partition::V12(dl) => &dl.recoveries,
+        }
+    }
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Add a `Partition::recovering_sectors` method

Needed for https://github.com/ChainSafe/forest/pull/3779

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->