### PR TITLE
Changes to market state for Forest `StateMarketStorageDeal` RPC method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "arrayref"
@@ -48,13 +48,13 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -368,20 +368,19 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
 dependencies = [
- "cfg-if",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -391,56 +390,46 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -566,7 +555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -597,7 +586,7 @@ checksum = "ce8cd46a041ad005ab9c71263f9a0ff5b529eac0fe4cc9b4a20f4f0765d8cf4b"
 dependencies = [
  "execute-command-tokens",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1303,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1423,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "keccak"
@@ -1447,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libipld-core"
@@ -1490,9 +1479,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
@@ -1501,15 +1490,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1653,7 +1633,7 @@ checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1844,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -1875,9 +1855,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1996,15 +1976,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.27"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfeae074e687625746172d639330f1de242a178bf3189b51e35a7a21573513ac"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2015,9 +1995,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "scopeguard"
@@ -2027,15 +2007,15 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
@@ -2051,22 +2031,22 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.12"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2083,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -2094,20 +2074,20 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
+checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -2135,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.27"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
+checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2362,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2391,35 +2371,35 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2517,9 +2497,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "unsigned-varint"
@@ -2566,15 +2546,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "windows-sys"
@@ -2701,9 +2672,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.26"
+version = "0.5.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67b5f0a4e7a27a64c651977932b9dc5667ca7fc31ac44b03ed37a0cf42fdfff"
+checksum = "b7520bbdec7211caa7c4e682eb1fbe07abe20cee6756b6e00f537c82c11816aa"
 dependencies = [
  "memchr",
 ]
@@ -2750,5 +2721,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]

--- a/fil_actor_interface/src/builtin/market/mod.rs
+++ b/fil_actor_interface/src/builtin/market/mod.rs
@@ -243,7 +243,7 @@ impl<BS> DealProposals<'_, BS> {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct DealProposal {
     #[serde(rename = "PieceCID")]
@@ -309,7 +309,7 @@ where
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct DealState {
     pub sector_start_epoch: ChainEpoch, // -1 if not yet included in proven sector

--- a/fil_actor_interface/src/builtin/market/mod.rs
+++ b/fil_actor_interface/src/builtin/market/mod.rs
@@ -39,6 +39,8 @@ pub const ADDRESS: Address = Address::new_id(5);
 /// Market actor method.
 pub type Method = fil_actor_market_state::v8::Method;
 
+pub type AllocationID = u64;
+
 pub fn is_v8_market_cid(cid: &Cid) -> bool {
     crate::KNOWN_CIDS.actor.market.v8.contains(cid)
 }
@@ -277,26 +279,31 @@ where
                 sector_start_epoch: deal_state.sector_start_epoch,
                 last_updated_epoch: deal_state.last_updated_epoch,
                 slash_epoch: deal_state.slash_epoch,
+                verified_claim: deal_state.verified_claim,
             })),
             DealStates::V9(deal_array) => Ok(deal_array.get(key)?.map(|deal_state| DealState {
                 sector_start_epoch: deal_state.sector_start_epoch,
                 last_updated_epoch: deal_state.last_updated_epoch,
                 slash_epoch: deal_state.slash_epoch,
+                verified_claim: deal_state.verified_claim,
             })),
             DealStates::V10(deal_array) => Ok(deal_array.get(key)?.map(|deal_state| DealState {
                 sector_start_epoch: deal_state.sector_start_epoch,
                 last_updated_epoch: deal_state.last_updated_epoch,
                 slash_epoch: deal_state.slash_epoch,
+                verified_claim: deal_state.verified_claim,
             })),
             DealStates::V11(deal_array) => Ok(deal_array.get(key)?.map(|deal_state| DealState {
                 sector_start_epoch: deal_state.sector_start_epoch,
                 last_updated_epoch: deal_state.last_updated_epoch,
                 slash_epoch: deal_state.slash_epoch,
+                verified_claim: deal_state.verified_claim,
             })),
             DealStates::V12(deal_array) => Ok(deal_array.get(key)?.map(|deal_state| DealState {
                 sector_start_epoch: deal_state.sector_start_epoch,
                 last_updated_epoch: deal_state.last_updated_epoch,
                 slash_epoch: deal_state.slash_epoch,
+                verified_claim: deal_state.verified_claim,
             })),
         }
     }
@@ -308,6 +315,7 @@ pub struct DealState {
     pub sector_start_epoch: ChainEpoch, // -1 if not yet included in proven sector
     pub last_updated_epoch: ChainEpoch, // -1 if deal state never updated
     pub slash_epoch: ChainEpoch,        // -1 if deal never slashed
+    pub verified_claim: AllocationID,   // ID of the verified registry allocation/claim for this deal's data (0 if none).
 }
 
 impl<BS> BalanceTable<'_, BS>

--- a/fil_actor_interface/src/builtin/market/mod.rs
+++ b/fil_actor_interface/src/builtin/market/mod.rs
@@ -197,125 +197,19 @@ impl<BS> DealProposals<'_, BS> {
     {
         match self {
             DealProposals::V9(deal_array) => {
-                deal_array.for_each(|key, deal_proposal| {
-                    f(
-                        key,
-                        DealProposal {
-                            piece_cid: deal_proposal.piece_cid,
-                            piece_size: deal_proposal.piece_size,
-                            verified_deal: deal_proposal.verified_deal,
-                            client: deal_proposal.client,
-                            provider: deal_proposal.provider,
-                            label: match &deal_proposal.label {
-                                fil_actor_market_state::v9::Label::String(s) => s.clone(),
-                                fil_actor_market_state::v9::Label::Bytes(b) => {
-                                    String::from_utf8(b.clone())?
-                                }
-                            },
-                            start_epoch: deal_proposal.start_epoch,
-                            end_epoch: deal_proposal.end_epoch,
-                            storage_price_per_epoch: deal_proposal.storage_price_per_epoch.clone(),
-                            provider_collateral: deal_proposal.provider_collateral.clone(),
-                            client_collateral: deal_proposal.client_collateral.clone(),
-                        },
-                    )
-                })?;
+                deal_array.for_each(|key, deal_proposal| f(key, deal_proposal.into()))?;
                 Ok(())
             }
             DealProposals::V10(deal_array) => {
-                deal_array.for_each(|key, deal_proposal| {
-                    f(
-                        key,
-                        DealProposal {
-                            piece_cid: deal_proposal.piece_cid,
-                            piece_size: from_padded_piece_size_v3_to_v2(deal_proposal.piece_size),
-                            verified_deal: deal_proposal.verified_deal,
-                            client: from_address_v3_to_v2(deal_proposal.client),
-                            provider: from_address_v3_to_v2(deal_proposal.provider),
-                            label: match &deal_proposal.label {
-                                fil_actor_market_state::v10::Label::String(s) => s.clone(),
-                                fil_actor_market_state::v10::Label::Bytes(b) => {
-                                    String::from_utf8(b.clone())?
-                                }
-                            },
-                            start_epoch: deal_proposal.start_epoch,
-                            end_epoch: deal_proposal.end_epoch,
-                            storage_price_per_epoch: from_token_v3_to_v2(
-                                deal_proposal.storage_price_per_epoch.clone(),
-                            ),
-                            provider_collateral: from_token_v3_to_v2(
-                                deal_proposal.provider_collateral.clone(),
-                            ),
-                            client_collateral: from_token_v3_to_v2(
-                                deal_proposal.client_collateral.clone(),
-                            ),
-                        },
-                    )
-                })?;
+                deal_array.for_each(|key, deal_proposal| f(key, deal_proposal.into()))?;
                 Ok(())
             }
             DealProposals::V11(deal_array) => {
-                deal_array.for_each(|key, deal_proposal| {
-                    f(
-                        key,
-                        DealProposal {
-                            piece_cid: deal_proposal.piece_cid,
-                            piece_size: from_padded_piece_size_v3_to_v2(deal_proposal.piece_size),
-                            verified_deal: deal_proposal.verified_deal,
-                            client: from_address_v3_to_v2(deal_proposal.client),
-                            provider: from_address_v3_to_v2(deal_proposal.provider),
-                            label: match &deal_proposal.label {
-                                fil_actor_market_state::v11::Label::String(s) => s.clone(),
-                                fil_actor_market_state::v11::Label::Bytes(b) => {
-                                    String::from_utf8(b.clone())?
-                                }
-                            },
-                            start_epoch: deal_proposal.start_epoch,
-                            end_epoch: deal_proposal.end_epoch,
-                            storage_price_per_epoch: from_token_v3_to_v2(
-                                deal_proposal.storage_price_per_epoch.clone(),
-                            ),
-                            provider_collateral: from_token_v3_to_v2(
-                                deal_proposal.provider_collateral.clone(),
-                            ),
-                            client_collateral: from_token_v3_to_v2(
-                                deal_proposal.client_collateral.clone(),
-                            ),
-                        },
-                    )
-                })?;
+                deal_array.for_each(|key, deal_proposal| f(key, deal_proposal.into()))?;
                 Ok(())
             }
             DealProposals::V12(deal_array) => {
-                deal_array.for_each(|key, deal_proposal| {
-                    f(
-                        key,
-                        DealProposal {
-                            piece_cid: deal_proposal.piece_cid,
-                            piece_size: from_padded_piece_size_v4_to_v2(deal_proposal.piece_size),
-                            verified_deal: deal_proposal.verified_deal,
-                            client: from_address_v4_to_v2(deal_proposal.client),
-                            provider: from_address_v4_to_v2(deal_proposal.provider),
-                            label: match &deal_proposal.label {
-                                fil_actor_market_state::v12::Label::String(s) => s.clone(),
-                                fil_actor_market_state::v12::Label::Bytes(b) => {
-                                    String::from_utf8(b.clone())?
-                                }
-                            },
-                            start_epoch: deal_proposal.start_epoch,
-                            end_epoch: deal_proposal.end_epoch,
-                            storage_price_per_epoch: from_token_v4_to_v2(
-                                deal_proposal.storage_price_per_epoch.clone(),
-                            ),
-                            provider_collateral: from_token_v4_to_v2(
-                                deal_proposal.provider_collateral.clone(),
-                            ),
-                            client_collateral: from_token_v4_to_v2(
-                                deal_proposal.client_collateral.clone(),
-                            ),
-                        },
-                    )
-                })?;
+                deal_array.for_each(|key, deal_proposal| f(key, deal_proposal.into()))?;
                 Ok(())
             }
         }
@@ -338,6 +232,104 @@ pub struct DealProposal {
     pub storage_price_per_epoch: TokenAmount,
     pub provider_collateral: TokenAmount,
     pub client_collateral: TokenAmount,
+}
+
+impl From<&fil_actor_market_state::v9::DealProposal> for DealProposal {
+    fn from(deal_proposal: &fil_actor_market_state::v9::DealProposal) -> Self {
+        Self {
+            piece_cid: deal_proposal.piece_cid,
+            piece_size: deal_proposal.piece_size,
+            verified_deal: deal_proposal.verified_deal,
+            client: deal_proposal.client,
+            provider: deal_proposal.provider,
+            label: match &deal_proposal.label {
+                fil_actor_market_state::v9::Label::String(s) => s.clone(),
+                fil_actor_market_state::v9::Label::Bytes(b) => {
+                    String::from_utf8(b.clone()).expect("failed to deserialize utf8 string")
+                }
+            },
+            start_epoch: deal_proposal.start_epoch,
+            end_epoch: deal_proposal.end_epoch,
+            storage_price_per_epoch: deal_proposal.storage_price_per_epoch.clone(),
+            provider_collateral: deal_proposal.provider_collateral.clone(),
+            client_collateral: deal_proposal.client_collateral.clone(),
+        }
+    }
+}
+
+impl From<&fil_actor_market_state::v10::DealProposal> for DealProposal {
+    fn from(deal_proposal: &fil_actor_market_state::v10::DealProposal) -> Self {
+        Self {
+            piece_cid: deal_proposal.piece_cid,
+            piece_size: from_padded_piece_size_v3_to_v2(deal_proposal.piece_size),
+            verified_deal: deal_proposal.verified_deal,
+            client: from_address_v3_to_v2(deal_proposal.client),
+            provider: from_address_v3_to_v2(deal_proposal.provider),
+            label: match &deal_proposal.label {
+                fil_actor_market_state::v10::Label::String(s) => s.clone(),
+                fil_actor_market_state::v10::Label::Bytes(b) => {
+                    String::from_utf8(b.clone()).expect("failed to deserialize utf8 string")
+                }
+            },
+            start_epoch: deal_proposal.start_epoch,
+            end_epoch: deal_proposal.end_epoch,
+            storage_price_per_epoch: from_token_v3_to_v2(
+                deal_proposal.storage_price_per_epoch.clone(),
+            ),
+            provider_collateral: from_token_v3_to_v2(deal_proposal.provider_collateral.clone()),
+            client_collateral: from_token_v3_to_v2(deal_proposal.client_collateral.clone()),
+        }
+    }
+}
+
+impl From<&fil_actor_market_state::v11::DealProposal> for DealProposal {
+    fn from(deal_proposal: &fil_actor_market_state::v11::DealProposal) -> Self {
+        Self {
+            piece_cid: deal_proposal.piece_cid,
+            piece_size: from_padded_piece_size_v3_to_v2(deal_proposal.piece_size),
+            verified_deal: deal_proposal.verified_deal,
+            client: from_address_v3_to_v2(deal_proposal.client),
+            provider: from_address_v3_to_v2(deal_proposal.provider),
+            label: match &deal_proposal.label {
+                fil_actor_market_state::v11::Label::String(s) => s.clone(),
+                fil_actor_market_state::v11::Label::Bytes(b) => {
+                    String::from_utf8(b.clone()).expect("failed to deserialize utf8 string")
+                }
+            },
+            start_epoch: deal_proposal.start_epoch,
+            end_epoch: deal_proposal.end_epoch,
+            storage_price_per_epoch: from_token_v3_to_v2(
+                deal_proposal.storage_price_per_epoch.clone(),
+            ),
+            provider_collateral: from_token_v3_to_v2(deal_proposal.provider_collateral.clone()),
+            client_collateral: from_token_v3_to_v2(deal_proposal.client_collateral.clone()),
+        }
+    }
+}
+
+impl From<&fil_actor_market_state::v12::DealProposal> for DealProposal {
+    fn from(deal_proposal: &fil_actor_market_state::v12::DealProposal) -> Self {
+        Self {
+            piece_cid: deal_proposal.piece_cid,
+            piece_size: from_padded_piece_size_v4_to_v2(deal_proposal.piece_size),
+            verified_deal: deal_proposal.verified_deal,
+            client: from_address_v4_to_v2(deal_proposal.client),
+            provider: from_address_v4_to_v2(deal_proposal.provider),
+            label: match &deal_proposal.label {
+                fil_actor_market_state::v12::Label::String(s) => s.clone(),
+                fil_actor_market_state::v12::Label::Bytes(b) => {
+                    String::from_utf8(b.clone()).expect("failed to deserialize utf8 string")
+                }
+            },
+            start_epoch: deal_proposal.start_epoch,
+            end_epoch: deal_proposal.end_epoch,
+            storage_price_per_epoch: from_token_v4_to_v2(
+                deal_proposal.storage_price_per_epoch.clone(),
+            ),
+            provider_collateral: from_token_v4_to_v2(deal_proposal.provider_collateral.clone()),
+            client_collateral: from_token_v4_to_v2(deal_proposal.client_collateral.clone()),
+        }
+    }
 }
 
 pub enum DealStates<'bs, BS> {

--- a/fil_actor_interface/src/builtin/market/mod.rs
+++ b/fil_actor_interface/src/builtin/market/mod.rs
@@ -197,19 +197,47 @@ impl<BS> DealProposals<'_, BS> {
     {
         match self {
             DealProposals::V9(deal_array) => {
-                deal_array.for_each(|key, deal_proposal| f(key, deal_proposal.into()))?;
+                deal_array.for_each(|key, deal_proposal| {
+                    f(
+                        key,
+                        deal_proposal
+                            .try_into()
+                            .expect("failed to convert V9 deal proposal to builtin version"),
+                    )
+                })?;
                 Ok(())
             }
             DealProposals::V10(deal_array) => {
-                deal_array.for_each(|key, deal_proposal| f(key, deal_proposal.into()))?;
+                deal_array.for_each(|key, deal_proposal| {
+                    f(
+                        key,
+                        deal_proposal
+                            .try_into()
+                            .expect("failed to convert V10 deal proposal to builtin version"),
+                    )
+                })?;
                 Ok(())
             }
             DealProposals::V11(deal_array) => {
-                deal_array.for_each(|key, deal_proposal| f(key, deal_proposal.into()))?;
+                deal_array.for_each(|key, deal_proposal| {
+                    f(
+                        key,
+                        deal_proposal
+                            .try_into()
+                            .expect("failed to convert V11 deal proposal to builtin version"),
+                    )
+                })?;
                 Ok(())
             }
             DealProposals::V12(deal_array) => {
-                deal_array.for_each(|key, deal_proposal| f(key, deal_proposal.into()))?;
+                deal_array.for_each(|key, deal_proposal| {
+                    f(
+                        key,
+                        deal_proposal
+                            .try_into()
+                            .expect("failed to convert V12 deal proposal to builtin version"),
+                    )
+                })?;
                 Ok(())
             }
         }
@@ -234,43 +262,53 @@ pub struct DealProposal {
     pub client_collateral: TokenAmount,
 }
 
-impl From<&fil_actor_market_state::v9::DealProposal> for DealProposal {
-    fn from(deal_proposal: &fil_actor_market_state::v9::DealProposal) -> Self {
-        Self {
+impl TryFrom<&fil_actor_market_state::v9::DealProposal> for DealProposal {
+    type Error = String;
+
+    fn try_from(
+        deal_proposal: &fil_actor_market_state::v9::DealProposal,
+    ) -> Result<Self, Self::Error> {
+        let label = match &deal_proposal.label {
+            fil_actor_market_state::v9::Label::String(s) => s.clone(),
+            fil_actor_market_state::v9::Label::Bytes(b) => {
+                String::from_utf8(b.clone()).expect("failed to deserialize utf8 string")
+            }
+        };
+        Ok(Self {
             piece_cid: deal_proposal.piece_cid,
             piece_size: deal_proposal.piece_size,
             verified_deal: deal_proposal.verified_deal,
             client: deal_proposal.client,
             provider: deal_proposal.provider,
-            label: match &deal_proposal.label {
-                fil_actor_market_state::v9::Label::String(s) => s.clone(),
-                fil_actor_market_state::v9::Label::Bytes(b) => {
-                    String::from_utf8(b.clone()).expect("failed to deserialize utf8 string")
-                }
-            },
+            label,
             start_epoch: deal_proposal.start_epoch,
             end_epoch: deal_proposal.end_epoch,
             storage_price_per_epoch: deal_proposal.storage_price_per_epoch.clone(),
             provider_collateral: deal_proposal.provider_collateral.clone(),
             client_collateral: deal_proposal.client_collateral.clone(),
-        }
+        })
     }
 }
 
-impl From<&fil_actor_market_state::v10::DealProposal> for DealProposal {
-    fn from(deal_proposal: &fil_actor_market_state::v10::DealProposal) -> Self {
-        Self {
+impl TryFrom<&fil_actor_market_state::v10::DealProposal> for DealProposal {
+    type Error = String;
+
+    fn try_from(
+        deal_proposal: &fil_actor_market_state::v10::DealProposal,
+    ) -> Result<Self, Self::Error> {
+        let label = match &deal_proposal.label {
+            fil_actor_market_state::v10::Label::String(s) => s.clone(),
+            fil_actor_market_state::v10::Label::Bytes(b) => {
+                String::from_utf8(b.clone()).expect("failed to deserialize utf8 string")
+            }
+        };
+        Ok(Self {
             piece_cid: deal_proposal.piece_cid,
             piece_size: from_padded_piece_size_v3_to_v2(deal_proposal.piece_size),
             verified_deal: deal_proposal.verified_deal,
             client: from_address_v3_to_v2(deal_proposal.client),
             provider: from_address_v3_to_v2(deal_proposal.provider),
-            label: match &deal_proposal.label {
-                fil_actor_market_state::v10::Label::String(s) => s.clone(),
-                fil_actor_market_state::v10::Label::Bytes(b) => {
-                    String::from_utf8(b.clone()).expect("failed to deserialize utf8 string")
-                }
-            },
+            label,
             start_epoch: deal_proposal.start_epoch,
             end_epoch: deal_proposal.end_epoch,
             storage_price_per_epoch: from_token_v3_to_v2(
@@ -278,24 +316,29 @@ impl From<&fil_actor_market_state::v10::DealProposal> for DealProposal {
             ),
             provider_collateral: from_token_v3_to_v2(deal_proposal.provider_collateral.clone()),
             client_collateral: from_token_v3_to_v2(deal_proposal.client_collateral.clone()),
-        }
+        })
     }
 }
 
-impl From<&fil_actor_market_state::v11::DealProposal> for DealProposal {
-    fn from(deal_proposal: &fil_actor_market_state::v11::DealProposal) -> Self {
-        Self {
+impl TryFrom<&fil_actor_market_state::v11::DealProposal> for DealProposal {
+    type Error = String;
+
+    fn try_from(
+        deal_proposal: &fil_actor_market_state::v11::DealProposal,
+    ) -> Result<Self, Self::Error> {
+        let label = match &deal_proposal.label {
+            fil_actor_market_state::v11::Label::String(s) => s.clone(),
+            fil_actor_market_state::v11::Label::Bytes(b) => {
+                String::from_utf8(b.clone()).expect("failed to deserialize utf8 string")
+            }
+        };
+        Ok(Self {
             piece_cid: deal_proposal.piece_cid,
             piece_size: from_padded_piece_size_v3_to_v2(deal_proposal.piece_size),
             verified_deal: deal_proposal.verified_deal,
             client: from_address_v3_to_v2(deal_proposal.client),
             provider: from_address_v3_to_v2(deal_proposal.provider),
-            label: match &deal_proposal.label {
-                fil_actor_market_state::v11::Label::String(s) => s.clone(),
-                fil_actor_market_state::v11::Label::Bytes(b) => {
-                    String::from_utf8(b.clone()).expect("failed to deserialize utf8 string")
-                }
-            },
+            label,
             start_epoch: deal_proposal.start_epoch,
             end_epoch: deal_proposal.end_epoch,
             storage_price_per_epoch: from_token_v3_to_v2(
@@ -303,24 +346,29 @@ impl From<&fil_actor_market_state::v11::DealProposal> for DealProposal {
             ),
             provider_collateral: from_token_v3_to_v2(deal_proposal.provider_collateral.clone()),
             client_collateral: from_token_v3_to_v2(deal_proposal.client_collateral.clone()),
-        }
+        })
     }
 }
 
-impl From<&fil_actor_market_state::v12::DealProposal> for DealProposal {
-    fn from(deal_proposal: &fil_actor_market_state::v12::DealProposal) -> Self {
-        Self {
+impl TryFrom<&fil_actor_market_state::v12::DealProposal> for DealProposal {
+    type Error = String;
+
+    fn try_from(
+        deal_proposal: &fil_actor_market_state::v12::DealProposal,
+    ) -> Result<Self, Self::Error> {
+        let label = match &deal_proposal.label {
+            fil_actor_market_state::v12::Label::String(s) => s.clone(),
+            fil_actor_market_state::v12::Label::Bytes(b) => {
+                String::from_utf8(b.clone()).expect("failed to deserialize utf8 string")
+            }
+        };
+        Ok(Self {
             piece_cid: deal_proposal.piece_cid,
             piece_size: from_padded_piece_size_v4_to_v2(deal_proposal.piece_size),
             verified_deal: deal_proposal.verified_deal,
             client: from_address_v4_to_v2(deal_proposal.client),
             provider: from_address_v4_to_v2(deal_proposal.provider),
-            label: match &deal_proposal.label {
-                fil_actor_market_state::v12::Label::String(s) => s.clone(),
-                fil_actor_market_state::v12::Label::Bytes(b) => {
-                    String::from_utf8(b.clone()).expect("failed to deserialize utf8 string")
-                }
-            },
+            label,
             start_epoch: deal_proposal.start_epoch,
             end_epoch: deal_proposal.end_epoch,
             storage_price_per_epoch: from_token_v4_to_v2(
@@ -328,7 +376,7 @@ impl From<&fil_actor_market_state::v12::DealProposal> for DealProposal {
             ),
             provider_collateral: from_token_v4_to_v2(deal_proposal.provider_collateral.clone()),
             client_collateral: from_token_v4_to_v2(deal_proposal.client_collateral.clone()),
-        }
+        })
     }
 }
 

--- a/fil_actor_interface/src/builtin/market/mod.rs
+++ b/fil_actor_interface/src/builtin/market/mod.rs
@@ -124,9 +124,9 @@ impl State {
     {
         match self {
             // `get_proposal_array` does not exist for V8
-            State::V8(_st) => unimplemented!(),
+            State::V8(_st) => anyhow::bail!("unimplemented"),
             // `get_proposal_array` does not exist for V9
-            State::V9(_st) => unimplemented!(),
+            State::V9(_st) => anyhow::bail!("unimplemented"),
             State::V10(st) => Ok(DealProposals::V10(st.get_proposal_array(store)?)),
             State::V11(st) => Ok(DealProposals::V11(st.get_proposal_array(store)?)),
             State::V12(st) => Ok(DealProposals::V12(st.get_proposal_array(store)?)),
@@ -140,7 +140,7 @@ impl State {
     {
         match self {
             // `DealMetaArray::load` does not exist for V8
-            State::V8(_st) => unimplemented!(),
+            State::V8(_st) => anyhow::bail!("unimplemented"),
             State::V9(st) => Ok(DealStates::V9(V9AsActorError::context_code(
                 V9DealMetaArray::load(&st.states, store),
                 FVMExitCode::USR_ILLEGAL_STATE,

--- a/fil_actor_interface/src/builtin/market/mod.rs
+++ b/fil_actor_interface/src/builtin/market/mod.rs
@@ -271,29 +271,29 @@ impl<BS> DealStates<'_, BS>
 where
     BS: Blockstore,
 {
-    pub fn get(&self, _key: u64) -> anyhow::Result<Option<DealState>> {
+    pub fn get(&self, key: u64) -> anyhow::Result<Option<DealState>> {
         match self {
-            DealStates::V8(deal_array) => Ok(deal_array.get(_key)?.map(|deal_state| DealState {
+            DealStates::V8(deal_array) => Ok(deal_array.get(key)?.map(|deal_state| DealState {
                 sector_start_epoch: deal_state.sector_start_epoch,
                 last_updated_epoch: deal_state.last_updated_epoch,
                 slash_epoch: deal_state.slash_epoch,
             })),
-            DealStates::V9(deal_array) => Ok(deal_array.get(_key)?.map(|deal_state| DealState {
+            DealStates::V9(deal_array) => Ok(deal_array.get(key)?.map(|deal_state| DealState {
                 sector_start_epoch: deal_state.sector_start_epoch,
                 last_updated_epoch: deal_state.last_updated_epoch,
                 slash_epoch: deal_state.slash_epoch,
             })),
-            DealStates::V10(deal_array) => Ok(deal_array.get(_key)?.map(|deal_state| DealState {
+            DealStates::V10(deal_array) => Ok(deal_array.get(key)?.map(|deal_state| DealState {
                 sector_start_epoch: deal_state.sector_start_epoch,
                 last_updated_epoch: deal_state.last_updated_epoch,
                 slash_epoch: deal_state.slash_epoch,
             })),
-            DealStates::V11(deal_array) => Ok(deal_array.get(_key)?.map(|deal_state| DealState {
+            DealStates::V11(deal_array) => Ok(deal_array.get(key)?.map(|deal_state| DealState {
                 sector_start_epoch: deal_state.sector_start_epoch,
                 last_updated_epoch: deal_state.last_updated_epoch,
                 slash_epoch: deal_state.slash_epoch,
             })),
-            DealStates::V12(deal_array) => Ok(deal_array.get(_key)?.map(|deal_state| DealState {
+            DealStates::V12(deal_array) => Ok(deal_array.get(key)?.map(|deal_state| DealState {
                 sector_start_epoch: deal_state.sector_start_epoch,
                 last_updated_epoch: deal_state.last_updated_epoch,
                 slash_epoch: deal_state.slash_epoch,

--- a/fil_actor_interface/src/builtin/market/mod.rs
+++ b/fil_actor_interface/src/builtin/market/mod.rs
@@ -209,7 +209,7 @@ impl<BS> DealProposals<'_, BS> {
                             label: match &deal_proposal.label {
                                 fil_actor_market_state::v9::Label::String(s) => s.clone(),
                                 fil_actor_market_state::v9::Label::Bytes(b) => {
-                                    String::from_utf8(b.clone()).unwrap()
+                                    String::from_utf8(b.clone())?
                                 }
                             },
                             start_epoch: deal_proposal.start_epoch,
@@ -235,7 +235,7 @@ impl<BS> DealProposals<'_, BS> {
                             label: match &deal_proposal.label {
                                 fil_actor_market_state::v10::Label::String(s) => s.clone(),
                                 fil_actor_market_state::v10::Label::Bytes(b) => {
-                                    String::from_utf8(b.clone()).unwrap()
+                                    String::from_utf8(b.clone())?
                                 }
                             },
                             start_epoch: deal_proposal.start_epoch,
@@ -267,7 +267,7 @@ impl<BS> DealProposals<'_, BS> {
                             label: match &deal_proposal.label {
                                 fil_actor_market_state::v11::Label::String(s) => s.clone(),
                                 fil_actor_market_state::v11::Label::Bytes(b) => {
-                                    String::from_utf8(b.clone()).unwrap()
+                                    String::from_utf8(b.clone())?
                                 }
                             },
                             start_epoch: deal_proposal.start_epoch,
@@ -299,7 +299,7 @@ impl<BS> DealProposals<'_, BS> {
                             label: match &deal_proposal.label {
                                 fil_actor_market_state::v12::Label::String(s) => s.clone(),
                                 fil_actor_market_state::v12::Label::Bytes(b) => {
-                                    String::from_utf8(b.clone()).unwrap()
+                                    String::from_utf8(b.clone())?
                                 }
                             },
                             start_epoch: deal_proposal.start_epoch,

--- a/fil_actor_interface/src/builtin/market/mod.rs
+++ b/fil_actor_interface/src/builtin/market/mod.rs
@@ -21,7 +21,7 @@ use fvm_shared::error::ExitCode as FVMExitCode;
 use fvm_shared::{address::Address, clock::ChainEpoch, econ::TokenAmount, piece::PaddedPieceSize};
 use fvm_shared3::error::ExitCode as FVM3ExitCode;
 use fvm_shared4::error::ExitCode as FVM4ExitCode;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
 use crate::io::get_obj;
@@ -196,7 +196,7 @@ impl<BS> DealProposals<'_, BS> {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct DealProposal {
     #[serde(rename = "PieceCID")]
@@ -231,7 +231,7 @@ where
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct DealState {
     pub sector_start_epoch: ChainEpoch, // -1 if not yet included in proven sector

--- a/fil_actor_interface/src/builtin/market/mod.rs
+++ b/fil_actor_interface/src/builtin/market/mod.rs
@@ -123,9 +123,9 @@ impl State {
         BS: Blockstore,
     {
         match self {
-            // `get_proposal_array` DNE for V8
+            // `get_proposal_array` does not exist for V8
             State::V8(_st) => unimplemented!(),
-            // `get_proposal_array` DNE for V9
+            // `get_proposal_array` does not exist for V9
             State::V9(_st) => unimplemented!(),
             State::V10(st) => Ok(DealProposals::V10(st.get_proposal_array(store)?)),
             State::V11(st) => Ok(DealProposals::V11(st.get_proposal_array(store)?)),

--- a/fil_actor_interface/src/builtin/market/mod.rs
+++ b/fil_actor_interface/src/builtin/market/mod.rs
@@ -272,7 +272,33 @@ where
     BS: Blockstore,
 {
     pub fn get(&self, _key: u64) -> anyhow::Result<Option<DealState>> {
-        unimplemented!()
+        match self {
+            DealStates::V8(deal_array) => Ok(deal_array.get(_key)?.map(|deal_state| DealState {
+                sector_start_epoch: deal_state.sector_start_epoch,
+                last_updated_epoch: deal_state.last_updated_epoch,
+                slash_epoch: deal_state.slash_epoch,
+            })),
+            DealStates::V9(deal_array) => Ok(deal_array.get(_key)?.map(|deal_state| DealState {
+                sector_start_epoch: deal_state.sector_start_epoch,
+                last_updated_epoch: deal_state.last_updated_epoch,
+                slash_epoch: deal_state.slash_epoch,
+            })),
+            DealStates::V10(deal_array) => Ok(deal_array.get(_key)?.map(|deal_state| DealState {
+                sector_start_epoch: deal_state.sector_start_epoch,
+                last_updated_epoch: deal_state.last_updated_epoch,
+                slash_epoch: deal_state.slash_epoch,
+            })),
+            DealStates::V11(deal_array) => Ok(deal_array.get(_key)?.map(|deal_state| DealState {
+                sector_start_epoch: deal_state.sector_start_epoch,
+                last_updated_epoch: deal_state.last_updated_epoch,
+                slash_epoch: deal_state.slash_epoch,
+            })),
+            DealStates::V12(deal_array) => Ok(deal_array.get(_key)?.map(|deal_state| DealState {
+                sector_start_epoch: deal_state.sector_start_epoch,
+                last_updated_epoch: deal_state.last_updated_epoch,
+                slash_epoch: deal_state.slash_epoch,
+            })),
+        }
     }
 }
 

--- a/fil_actor_interface/src/convert.rs
+++ b/fil_actor_interface/src/convert.rs
@@ -10,6 +10,7 @@ use fil_actors_shared::v12::runtime::ProofSet as ProofSetV12;
 use fil_actors_shared::v9::runtime::Policy as PolicyV9;
 use fvm_shared::address::Address as AddressV2;
 use fvm_shared::econ::TokenAmount as TokenAmountV2;
+use fvm_shared::piece::PaddedPieceSize as PaddedPieceSizeV2;
 use fvm_shared::sector::RegisteredPoStProof as RegisteredPoStProofV2;
 use fvm_shared::sector::RegisteredSealProof as RegisteredSealProofV2;
 use fvm_shared::sector::SectorSize as SectorSizeV2;
@@ -22,10 +23,15 @@ use fvm_shared3::sector::SectorSize as SectorSizeV3;
 use fvm_shared3::smooth::FilterEstimate as FilterEstimateV3;
 use fvm_shared4::address::Address as AddressV4;
 use fvm_shared4::econ::TokenAmount as TokenAmountV4;
+use fvm_shared4::piece::PaddedPieceSize as PaddedPieceSizeV4;
 use fvm_shared4::sector::RegisteredPoStProof as RegisteredPoStProofV4;
 use fvm_shared4::sector::RegisteredSealProof as RegisteredSealProofV4;
 use fvm_shared4::sector::SectorSize as SectorSizeV4;
 use fvm_shared4::smooth::FilterEstimate as FilterEstimateV4;
+
+pub fn from_padded_piece_size_v4_to_v2(size: PaddedPieceSizeV4) -> PaddedPieceSizeV2 {
+    PaddedPieceSizeV2(size.0)
+}
 
 pub fn from_reg_seal_proof_v3_to_v2(proof: RegisteredSealProofV3) -> RegisteredSealProofV2 {
     let num_id: i64 = proof.into();

--- a/fil_actor_interface/src/convert.rs
+++ b/fil_actor_interface/src/convert.rs
@@ -17,6 +17,7 @@ use fvm_shared::sector::SectorSize as SectorSizeV2;
 use fvm_shared::smooth::FilterEstimate as FilterEstimateV2;
 use fvm_shared3::address::Address as AddressV3;
 use fvm_shared3::econ::TokenAmount as TokenAmountV3;
+use fvm_shared3::piece::PaddedPieceSize as PaddedPieceSizeV3;
 use fvm_shared3::sector::RegisteredPoStProof as RegisteredPoStProofV3;
 use fvm_shared3::sector::RegisteredSealProof as RegisteredSealProofV3;
 use fvm_shared3::sector::SectorSize as SectorSizeV3;
@@ -30,6 +31,10 @@ use fvm_shared4::sector::SectorSize as SectorSizeV4;
 use fvm_shared4::smooth::FilterEstimate as FilterEstimateV4;
 
 pub fn from_padded_piece_size_v4_to_v2(size: PaddedPieceSizeV4) -> PaddedPieceSizeV2 {
+    PaddedPieceSizeV2(size.0)
+}
+
+pub fn from_padded_piece_size_v3_to_v2(size: PaddedPieceSizeV3) -> PaddedPieceSizeV2 {
     PaddedPieceSizeV2(size.0)
 }
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Implement `State::states`, `State::proposals`, `DealProposals::for_each`, `DealStates::get`, ... methods to properly implement Forest `StateMarketStorageDeal` RPC method ([related PR](https://github.com/ChainSafe/forest/pull/3815)).
- Update `derive` macros for `DealProposal` and `DealState`.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
N/A


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->