### PR TITLE
Add get pending transaction method for multisig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,7 @@ dependencies = [
  "fvm_shared 2.6.0",
  "fvm_shared 3.6.0",
  "fvm_shared 4.0.0",
+ "integer-encoding",
  "lazy_static",
  "multihash",
  "num",

--- a/actors/multisig/src/v12/state.rs
+++ b/actors/multisig/src/v12/state.rs
@@ -5,11 +5,11 @@ use cid::Cid;
 use fil_actors_shared::v12::{ActorError, Config, Map2, DEFAULT_HAMT_CONFIG};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
-use fvm_shared::address::Address;
-use fvm_shared::bigint::BigInt;
-use fvm_shared::bigint::Integer;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
+use fvm_shared4::address::Address;
+use fvm_shared4::bigint::BigInt;
+use fvm_shared4::bigint::Integer;
+use fvm_shared4::clock::ChainEpoch;
+use fvm_shared4::econ::TokenAmount;
 use indexmap::IndexMap;
 use num_traits::Zero;
 

--- a/actors/multisig/src/v12/types.rs
+++ b/actors/multisig/src/v12/types.rs
@@ -5,11 +5,11 @@ use std::fmt::Display;
 
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{strict_bytes, RawBytes};
-use fvm_shared::address::Address;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::error::ExitCode;
-use fvm_shared::MethodNum;
+use fvm_shared4::address::Address;
+use fvm_shared4::clock::ChainEpoch;
+use fvm_shared4::econ::TokenAmount;
+use fvm_shared4::error::ExitCode;
+use fvm_shared4::MethodNum;
 use serde::{Deserialize, Serialize};
 
 use fil_actors_shared::v12::MapKey;

--- a/fil_actor_interface/Cargo.toml
+++ b/fil_actor_interface/Cargo.toml
@@ -30,6 +30,7 @@ fvm_ipld_encoding.workspace = true
 fvm_shared = { workspace = true }
 fvm_shared3 = { workspace = true }
 fvm_shared4 = { workspace = true }
+integer-encoding.workspace = true
 lazy_static.workspace = true
 multihash = { workspace = true, features = ["identity"] }
 num.workspace = true

--- a/fil_actor_interface/src/builtin/multisig/mod.rs
+++ b/fil_actor_interface/src/builtin/multisig/mod.rs
@@ -4,7 +4,6 @@
 use crate::convert::{
     from_address_v3_to_v2, from_address_v4_to_v2, from_token_v3_to_v2, from_token_v4_to_v2,
 };
-use crate::parse_pending_transactions;
 use anyhow::Context;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
@@ -112,7 +111,7 @@ impl State {
                     BS,
                     fil_actor_multisig_state::v8::Transaction,
                 >(&st.pending_txs, store)?;
-                parse_pending_transactions!(res, txns);
+                crate::parse_pending_transactions!(res, txns);
                 Ok(res)
             }
             State::V9(st) => {
@@ -120,7 +119,7 @@ impl State {
                     BS,
                     fil_actor_multisig_state::v9::Transaction,
                 >(&st.pending_txs, store)?;
-                parse_pending_transactions!(res, txns);
+                crate::parse_pending_transactions!(res, txns);
                 Ok(res)
             }
             State::V10(st) => {
@@ -128,13 +127,7 @@ impl State {
                     BS,
                     fil_actor_multisig_state::v10::Transaction,
                 >(&st.pending_txs, store)?;
-                parse_pending_transactions!(
-                    res,
-                    txns,
-                    from_address_v3_to_v2,
-                    from_token_v3_to_v2,
-                    :decode
-                );
+                crate::parse_pending_transactions_v3!(res, txns);
                 Ok(res)
             }
             State::V11(st) => {
@@ -142,13 +135,7 @@ impl State {
                     BS,
                     fil_actor_multisig_state::v11::Transaction,
                 >(&st.pending_txs, store)?;
-                parse_pending_transactions!(
-                    res,
-                    txns,
-                    from_address_v3_to_v2,
-                    from_token_v3_to_v2,
-                    :decode
-                );
+                crate::parse_pending_transactions_v3!(res, txns);
                 Ok(res)
             }
             State::V12(st) => {
@@ -159,13 +146,7 @@ impl State {
                     "pending txns",
                 )
                 .expect("Could not load pending transactions");
-                parse_pending_transactions!(
-                    res,
-                    txns,
-                    from_address_v4_to_v2,
-                    from_token_v4_to_v2,
-                    :no_decode
-                );
+                crate::parse_pending_transactions_v4!(res, txns);
                 Ok(res)
             }
         }

--- a/fil_actor_interface/src/builtin/multisig/mod.rs
+++ b/fil_actor_interface/src/builtin/multisig/mod.rs
@@ -1,12 +1,20 @@
 // Copyright 2019-2023 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use crate::convert::from_token_v3_to_v2;
+use crate::convert::{
+    from_address_v3_to_v2, from_address_v4_to_v2, from_token_v3_to_v2, from_token_v4_to_v2,
+};
 use anyhow::Context;
 use cid::Cid;
+use fil_actor_multisig_state::v10::Transaction as TransactionV10;
+use fil_actor_multisig_state::v11::Transaction as TransactionV11;
+use fil_actor_multisig_state::v12::Transaction as TransactionV12;
+use fil_actor_multisig_state::v8::Transaction as TransactionV8;
+use fil_actor_multisig_state::v9::Transaction as TransactionV9;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_shared::{clock::ChainEpoch, econ::TokenAmount};
-use serde::Serialize;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::{address::Address, clock::ChainEpoch, econ::TokenAmount, MethodNum};
+use serde::{Deserialize, Serialize};
 
 use crate::io::get_obj;
 
@@ -21,7 +29,18 @@ pub enum State {
     V9(fil_actor_multisig_state::v9::State),
     V10(fil_actor_multisig_state::v10::State),
     V11(fil_actor_multisig_state::v11::State),
-    V12(fil_actor_multisig_state::v11::State),
+    V12(fil_actor_multisig_state::v12::State),
+}
+
+/// Transaction type used in multisig actor
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct Transaction {
+    pub id: i64,
+    pub to: Address,
+    pub value: TokenAmount,
+    pub method: MethodNum,
+    pub params: RawBytes,
+    pub approved: Vec<Address>,
 }
 
 pub fn is_v8_multisig_cid(cid: &Cid) -> bool {
@@ -84,7 +103,127 @@ impl State {
             State::V9(st) => st.amount_locked(height),
             State::V10(st) => from_token_v3_to_v2(st.amount_locked(height)),
             State::V11(st) => from_token_v3_to_v2(st.amount_locked(height)),
-            State::V12(st) => from_token_v3_to_v2(st.amount_locked(height)),
+            State::V12(st) => from_token_v4_to_v2(st.amount_locked(height)),
         })
+    }
+
+    /// Returns pending transactions for the given multisig wallet
+    pub fn get_pending_txn<BS: Blockstore>(&self, store: &BS) -> anyhow::Result<Vec<Transaction>> {
+        let mut res = Vec::new();
+        match self {
+            State::V8(st) => {
+                let txns = fil_actors_shared::v8::make_map_with_root(&st.pending_txs, store)?;
+                txns.for_each(|tx_key, txn: &TransactionV8| {
+                    match integer_encoding::VarInt::decode_var(&tx_key) {
+                        Some((tx_id, _)) => {
+                            res.push(Transaction {
+                                id: tx_id,
+                                to: txn.to,
+                                value: txn.value.clone(),
+                                method: txn.method,
+                                params: txn.params.clone(),
+                                approved: txn.approved.clone(),
+                            });
+                        }
+                        None => anyhow::bail!("Error decoding varint"),
+                    }
+                    Ok(())
+                })?;
+                Ok(res)
+            }
+            State::V9(st) => {
+                let txns = fil_actors_shared::v9::make_map_with_root(&st.pending_txs, store)?;
+                txns.for_each(|tx_key, txn: &TransactionV9| {
+                    match integer_encoding::VarInt::decode_var(&tx_key) {
+                        Some((tx_id, _)) => {
+                            res.push(Transaction {
+                                id: tx_id,
+                                to: txn.to,
+                                value: txn.value.clone(),
+                                method: txn.method,
+                                params: txn.params.clone(),
+                                approved: txn.approved.clone(),
+                            });
+                        }
+                        None => anyhow::bail!("Error decoding varint"),
+                    }
+                    Ok(())
+                })?;
+                Ok(res)
+            }
+            State::V10(st) => {
+                let txns = fil_actors_shared::v10::make_map_with_root(&st.pending_txs, store)?;
+                txns.for_each(|tx_key, txn: &TransactionV10| {
+                    match integer_encoding::VarInt::decode_var(&tx_key) {
+                        Some((tx_id, _)) => {
+                            res.push(Transaction {
+                                id: tx_id,
+                                to: from_address_v3_to_v2(txn.to),
+                                value: from_token_v3_to_v2(txn.value.clone()),
+                                method: txn.method,
+                                params: txn.params.clone(),
+                                approved: txn
+                                    .approved
+                                    .iter()
+                                    .map(|&addr| from_address_v3_to_v2(addr))
+                                    .collect(),
+                            });
+                        }
+                        None => anyhow::bail!("Error decoding varint"),
+                    }
+                    Ok(())
+                })?;
+                Ok(res)
+            }
+            State::V11(st) => {
+                let txns = fil_actors_shared::v11::make_map_with_root(&st.pending_txs, store)?;
+                txns.for_each(|tx_key, txn: &TransactionV11| {
+                    match integer_encoding::VarInt::decode_var(&tx_key) {
+                        Some((tx_id, _)) => {
+                            res.push(Transaction {
+                                id: tx_id,
+                                to: from_address_v3_to_v2(txn.to),
+                                value: from_token_v3_to_v2(txn.value.clone()),
+                                method: txn.method,
+                                params: txn.params.clone(),
+                                approved: txn
+                                    .approved
+                                    .iter()
+                                    .map(|&addr| from_address_v3_to_v2(addr))
+                                    .collect(),
+                            });
+                        }
+                        None => anyhow::bail!("Error decoding varint"),
+                    }
+                    Ok(())
+                })?;
+                Ok(res)
+            }
+            State::V12(st) => {
+                let txns = fil_actor_multisig_state::v12::PendingTxnMap::load(
+                    store,
+                    &st.pending_txs,
+                    fil_actor_multisig_state::v12::PENDING_TXN_CONFIG,
+                    "pending txns",
+                )
+                .expect("Could not load pending transactions");
+                txns.for_each(|tx_id, txn: &TransactionV12| {
+                    res.push(Transaction {
+                        id: tx_id.0,
+                        to: from_address_v4_to_v2(txn.to),
+                        value: from_token_v4_to_v2(txn.value.clone()),
+                        method: txn.method,
+                        params: txn.params.clone(),
+                        approved: txn
+                            .approved
+                            .iter()
+                            .map(|&addr| from_address_v4_to_v2(addr))
+                            .collect(),
+                    });
+                    Ok(())
+                })?;
+                Ok(res)
+            }
+        }
     }
 }

--- a/fil_actor_interface/src/builtin/multisig/mod.rs
+++ b/fil_actor_interface/src/builtin/multisig/mod.rs
@@ -128,7 +128,13 @@ impl State {
                     BS,
                     fil_actor_multisig_state::v10::Transaction,
                 >(&st.pending_txs, store)?;
-                parse_pending_transactions!(res, txns, from_address_v3_to_v2, from_token_v3_to_v2);
+                parse_pending_transactions!(
+                    res,
+                    txns,
+                    from_address_v3_to_v2,
+                    from_token_v3_to_v2,
+                    :decode
+                );
                 Ok(res)
             }
             State::V11(st) => {
@@ -136,7 +142,13 @@ impl State {
                     BS,
                     fil_actor_multisig_state::v11::Transaction,
                 >(&st.pending_txs, store)?;
-                parse_pending_transactions!(res, txns, from_address_v3_to_v2, from_token_v3_to_v2);
+                parse_pending_transactions!(
+                    res,
+                    txns,
+                    from_address_v3_to_v2,
+                    from_token_v3_to_v2,
+                    :decode
+                );
                 Ok(res)
             }
             State::V12(st) => {
@@ -147,21 +159,13 @@ impl State {
                     "pending txns",
                 )
                 .expect("Could not load pending transactions");
-                txns.for_each(|tx_id, txn| {
-                    res.push(Transaction {
-                        id: tx_id.0,
-                        to: from_address_v4_to_v2(txn.to),
-                        value: from_token_v4_to_v2(txn.value.clone()),
-                        method: txn.method,
-                        params: txn.params.clone(),
-                        approved: txn
-                            .approved
-                            .iter()
-                            .map(|&addr| from_address_v4_to_v2(addr))
-                            .collect(),
-                    });
-                    Ok(())
-                })?;
+                parse_pending_transactions!(
+                    res,
+                    txns,
+                    from_address_v4_to_v2,
+                    from_token_v4_to_v2,
+                    :no_decode
+                );
                 Ok(res)
             }
         }

--- a/fil_actor_interface/src/builtin/multisig/mod.rs
+++ b/fil_actor_interface/src/builtin/multisig/mod.rs
@@ -4,7 +4,7 @@
 use crate::convert::{
     from_address_v3_to_v2, from_address_v4_to_v2, from_token_v3_to_v2, from_token_v4_to_v2,
 };
-use crate::parse_transactions;
+use crate::parse_pending_transactions;
 use anyhow::Context;
 use cid::Cid;
 use fvm_ipld_blockstore::Blockstore;
@@ -112,7 +112,7 @@ impl State {
                     BS,
                     fil_actor_multisig_state::v8::Transaction,
                 >(&st.pending_txs, store)?;
-                parse_transactions!(res, txns);
+                parse_pending_transactions!(res, txns);
                 Ok(res)
             }
             State::V9(st) => {
@@ -120,7 +120,7 @@ impl State {
                     BS,
                     fil_actor_multisig_state::v9::Transaction,
                 >(&st.pending_txs, store)?;
-                parse_transactions!(res, txns);
+                parse_pending_transactions!(res, txns);
                 Ok(res)
             }
             State::V10(st) => {
@@ -128,7 +128,7 @@ impl State {
                     BS,
                     fil_actor_multisig_state::v10::Transaction,
                 >(&st.pending_txs, store)?;
-                parse_transactions!(res, txns, from_address_v3_to_v2, from_token_v3_to_v2);
+                parse_pending_transactions!(res, txns, from_address_v3_to_v2, from_token_v3_to_v2);
                 Ok(res)
             }
             State::V11(st) => {
@@ -136,7 +136,7 @@ impl State {
                     BS,
                     fil_actor_multisig_state::v11::Transaction,
                 >(&st.pending_txs, store)?;
-                parse_transactions!(res, txns, from_address_v3_to_v2, from_token_v3_to_v2);
+                parse_pending_transactions!(res, txns, from_address_v3_to_v2, from_token_v3_to_v2);
                 Ok(res)
             }
             State::V12(st) => {

--- a/fil_actor_interface/src/lib.rs
+++ b/fil_actor_interface/src/lib.rs
@@ -4,6 +4,7 @@
 mod builtin;
 mod convert;
 mod io;
+mod macros;
 mod r#mod;
 
 pub use self::builtin::*;

--- a/fil_actor_interface/src/macros.rs
+++ b/fil_actor_interface/src/macros.rs
@@ -1,0 +1,46 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+#[macro_export]
+macro_rules! parse_transactions {
+    ($res:ident, $txns:expr, $from_address:expr, $from_token:expr) => {
+        $txns.for_each(|tx_key, txn| {
+            match integer_encoding::VarInt::decode_var(&tx_key) {
+                Some((tx_id, _)) => {
+                    $res.push(Transaction {
+                        id: tx_id,
+                        to: $from_address(txn.to),
+                        value: $from_token(txn.value.clone()),
+                        method: txn.method,
+                        params: txn.params.clone(),
+                        approved: txn
+                            .approved
+                            .iter()
+                            .map(|&addr| $from_address(addr))
+                            .collect(),
+                    });
+                }
+                None => anyhow::bail!("Error decoding varint"),
+            }
+            Ok(())
+        })?;
+    };
+    ($res:ident, $txns:expr) => {
+        $txns.for_each(|tx_key, txn| {
+            match integer_encoding::VarInt::decode_var(&tx_key) {
+                Some((tx_id, _)) => {
+                    $res.push(Transaction {
+                        id: tx_id,
+                        to: txn.to,
+                        value: txn.value.clone(),
+                        method: txn.method,
+                        params: txn.params.clone(),
+                        approved: txn.approved.clone(),
+                    });
+                }
+                None => anyhow::bail!("Error decoding varint"),
+            }
+            Ok(())
+        })?;
+    };
+}

--- a/fil_actor_interface/src/macros.rs
+++ b/fil_actor_interface/src/macros.rs
@@ -1,68 +1,14 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-/// `parse_pending_transactions` is a macro for parsing pending transactions and populating a vector with transaction data.
-/// It has three different patterns to match based on the provided arguments.
+/// This macro iterates over each transaction, decodes the transaction key using variable-length integer encoding,
+/// and constructs a Transaction object with the decoded data.
 ///
-/// # Arguments
-/// * `$res:ident` - A mutable reference to a vector where parsed transactions will be pushed.
-/// * `$txns:expr` - An expression that yields a collection of transactions to be parsed.
-/// * `$from_address:expr` - (Optional, based on pattern) A function for transforming address between different versions.
-/// * `$from_token:expr` - (Optional, based on pattern) A function for transforming token between different versions.
-/// * `true/false` - (Optional, based on pattern) A boolean flag to determine the parsing strategy for transaction id.
-///
-/// # Usage
-/// This macro supports three different invocation patterns:
-///
-/// 1. When `:decode` is passed as the last argument, it expects `$from_address` and `$from_token` to transform between different versions.
-///    The transaction ID is extracted and decoded using `integer_encoding::VarInt::decode_var`.
-///
-/// 2. When `:no_decode` is passed as the last argument, it also expects `$from_address` and `$from_token` to transform between different versions,
-///    but uses the transaction id directly as provided in `$txns`.
-///
-/// 3. When only `$res` and `$txns` are provided, it performs a basic parsing without transforming the 'to' address and 'value' fields.
-///    It also decodes the transaction ID using `integer_encoding::VarInt::decode_var`.
+/// Parameters:
+/// - `$res`: A mutable reference to a collection where the parsed transactions will be stored.
+/// - `$txns`: A collection of transaction data to be parsed.
 #[macro_export]
 macro_rules! parse_pending_transactions {
-    ($res:ident, $txns:expr, $from_address:expr, $from_token:expr, :decode) => {
-        $txns.for_each(|tx_key, txn| {
-            match integer_encoding::VarInt::decode_var(&tx_key) {
-                Some((tx_id, _)) => {
-                    $res.push(Transaction {
-                        id: tx_id,
-                        to: $from_address(txn.to),
-                        value: $from_token(txn.value.clone()),
-                        method: txn.method,
-                        params: txn.params.clone(),
-                        approved: txn
-                            .approved
-                            .iter()
-                            .map(|&addr| $from_address(addr))
-                            .collect(),
-                    });
-                }
-                None => anyhow::bail!("Error decoding varint"),
-            }
-            Ok(())
-        })?;
-    };
-    ($res:ident, $txns:expr, $from_address:expr, $from_token:expr, :no_decode) => {
-        $txns.for_each(|tx_id, txn| {
-            $res.push(Transaction {
-                id: tx_id.0,
-                to: $from_address(txn.to),
-                value: $from_token(txn.value.clone()),
-                method: txn.method,
-                params: txn.params.clone(),
-                approved: txn
-                    .approved
-                    .iter()
-                    .map(|&addr| $from_address(addr))
-                    .collect(),
-            });
-            Ok(())
-        })?;
-    };
     ($res:ident, $txns:expr) => {
         $txns.for_each(|tx_key, txn| {
             match integer_encoding::VarInt::decode_var(&tx_key) {
@@ -78,6 +24,66 @@ macro_rules! parse_pending_transactions {
                 }
                 None => anyhow::bail!("Error decoding varint"),
             }
+            Ok(())
+        })?;
+    };
+}
+
+/// This macro iterates over each transaction, decodes the transaction key, and constructs a Transaction object
+/// with additional processing for address and token formats using `from_address_v3_to_v2` and `from_token_v3_to_v2`.
+///
+/// Parameters:
+/// - `$res`: A mutable reference to a collection where the parsed transactions will be stored.
+/// - `$txns`: A collection of transaction data to be parsed.
+#[macro_export]
+macro_rules! parse_pending_transactions_v3 {
+    ($res:ident, $txns:expr) => {
+        $txns.for_each(|tx_key, txn| {
+            match integer_encoding::VarInt::decode_var(&tx_key) {
+                Some((tx_id, _)) => {
+                    $res.push(Transaction {
+                        id: tx_id,
+                        to: from_address_v3_to_v2(txn.to),
+                        value: from_token_v3_to_v2(txn.value.clone()),
+                        method: txn.method,
+                        params: txn.params.clone(),
+                        approved: txn
+                            .approved
+                            .iter()
+                            .map(|&addr| from_address_v3_to_v2(addr))
+                            .collect(),
+                    });
+                }
+                None => anyhow::bail!("Error decoding varint"),
+            }
+            Ok(())
+        })?;
+    };
+}
+
+/// This macro iterates over each transaction, assumes that transaction id's are directly available and not encoded.
+/// It constructs Transaction objects with transformations for address and token data from version 4 to version 2
+/// using `from_address_v4_to_v2` and `from_token_v4_to_v2`.
+///
+/// Parameters:
+/// - `$res`: A mutable reference to a collection where the parsed transactions will be stored.
+/// - `$txns`: A collection of transaction data to be parsed.
+#[macro_export]
+macro_rules! parse_pending_transactions_v4 {
+    ($res:ident, $txns:expr) => {
+        $txns.for_each(|tx_id, txn| {
+            $res.push(Transaction {
+                id: tx_id.0,
+                to: from_address_v4_to_v2(txn.to),
+                value: from_token_v4_to_v2(txn.value.clone()),
+                method: txn.method,
+                params: txn.params.clone(),
+                approved: txn
+                    .approved
+                    .iter()
+                    .map(|&addr| from_address_v4_to_v2(addr))
+                    .collect(),
+            });
             Ok(())
         })?;
     };

--- a/fil_actor_interface/src/macros.rs
+++ b/fil_actor_interface/src/macros.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 #[macro_export]
-macro_rules! parse_transactions {
+macro_rules! parse_pending_transactions {
     ($res:ident, $txns:expr, $from_address:expr, $from_token:expr) => {
         $txns.for_each(|tx_key, txn| {
             match integer_encoding::VarInt::decode_var(&tx_key) {

--- a/fil_actor_interface/src/macros.rs
+++ b/fil_actor_interface/src/macros.rs
@@ -1,9 +1,30 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+/// `parse_pending_transactions` is a macro for parsing pending transactions and populating a vector with transaction data.
+/// It has three different patterns to match based on the provided arguments.
+///
+/// # Arguments
+/// * `$res:ident` - A mutable reference to a vector where parsed transactions will be pushed.
+/// * `$txns:expr` - An expression that yields a collection of transactions to be parsed.
+/// * `$from_address:expr` - (Optional, based on pattern) A function for transforming address between different versions.
+/// * `$from_token:expr` - (Optional, based on pattern) A function for transforming token between different versions.
+/// * `true/false` - (Optional, based on pattern) A boolean flag to determine the parsing strategy for transaction id.
+///
+/// # Usage
+/// This macro supports three different invocation patterns:
+///
+/// 1. When `:decode` is passed as the last argument, it expects `$from_address` and `$from_token` to transform between different versions.
+///    The transaction ID is extracted and decoded using `integer_encoding::VarInt::decode_var`.
+///
+/// 2. When `:no_decode` is passed as the last argument, it also expects `$from_address` and `$from_token` to transform between different versions,
+///    but uses the transaction id directly as provided in `$txns`.
+///
+/// 3. When only `$res` and `$txns` are provided, it performs a basic parsing without transforming the 'to' address and 'value' fields.
+///    It also decodes the transaction ID using `integer_encoding::VarInt::decode_var`.
 #[macro_export]
 macro_rules! parse_pending_transactions {
-    ($res:ident, $txns:expr, $from_address:expr, $from_token:expr) => {
+    ($res:ident, $txns:expr, $from_address:expr, $from_token:expr, :decode) => {
         $txns.for_each(|tx_key, txn| {
             match integer_encoding::VarInt::decode_var(&tx_key) {
                 Some((tx_id, _)) => {
@@ -22,6 +43,23 @@ macro_rules! parse_pending_transactions {
                 }
                 None => anyhow::bail!("Error decoding varint"),
             }
+            Ok(())
+        })?;
+    };
+    ($res:ident, $txns:expr, $from_address:expr, $from_token:expr, :no_decode) => {
+        $txns.for_each(|tx_id, txn| {
+            $res.push(Transaction {
+                id: tx_id.0,
+                to: $from_address(txn.to),
+                value: $from_token(txn.value.clone()),
+                method: txn.method,
+                params: txn.params.clone(),
+                approved: txn
+                    .approved
+                    .iter()
+                    .map(|&addr| $from_address(addr))
+                    .collect(),
+            });
             Ok(())
         })?;
     };


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Added `get_pending_txn` method required for `MsigGetPending` [rpc](https://github.com/ChainSafe/forest/pull/3838)
- Use `fvm_shared4` instead of `fvm_shared` for multisig v12 


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->