### PR TITLE
chore: upgrade rust toolchain to 1.75.0

### DIFF
--- a/fil_actor_interface/src/builtin/known_cids.rs
+++ b/fil_actor_interface/src/builtin/known_cids.rs
@@ -222,6 +222,10 @@ impl CidPerNetwork {
     }
 }
 
+fn make_builtin(bz: &[u8]) -> Cid {
+    Cid::new_v1(RAW, Code::Identity.digest(bz))
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::{ensure, Ok, Result};
@@ -236,8 +240,4 @@ mod tests {
 
         Ok(())
     }
-}
-
-fn make_builtin(bz: &[u8]) -> Cid {
-    Cid::new_v1(RAW, Code::Identity.digest(bz))
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.75.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = []


### PR DESCRIPTION
**Summary of changes**

upgrade rust toolchain to 1.75.0 to align with forest repository

Changes introduced in this pull request:
- Fix all clippy warnings



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->

https://releases.rs/docs/1.75.0/

<!-- Thank you 🔥 -->