### PR TITLE
Remove pre release creation from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish and Release 
+name: Publish Crates
 
 on:
   workflow_dispatch:
@@ -7,7 +7,7 @@ on:
     - v*
 
 jobs:
-  publish_release:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -16,17 +16,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.4
         timeout-minutes: 5
         continue-on-error: true
-      - name: Publish
+      - name: Publish crates
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: ./scripts/publish.sh
-      - name: Create Pre-Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            Release notes for version ${{ github.ref }}:
-          prerelease: true


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Releases are now made via UI, so this step is not required in publish workflow
https://github.com/ChainSafe/fil-actor-states/pull/249



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->