### PR TITLE
chore: prepare release v10.0.0-dev.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "frc42_macros",
  "fvm_ipld_encoding",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared 2.6.0",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_datacap_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "fil_actors_shared",
  "frc42_macros",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_eam_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "fvm_shared 3.6.0",
  "fvm_shared 4.1.2",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_ethaccount_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared 3.6.0",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_evm_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "cid",
  "fil_actors_shared",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "anyhow",
  "cid",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_interface"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "anyhow",
  "cid",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "anyhow",
  "cid",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "anyhow",
  "bitflags 2.4.2",
@@ -815,7 +815,7 @@ dependencies = [
  "fvm_shared 3.6.0",
  "fvm_shared 4.1.2",
  "hex",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "multihash",
  "num-bigint",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "anyhow",
  "cid",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "cid",
  "fil_actors_shared",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "anyhow",
  "cid",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared 2.6.0",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "cid",
  "fil_actors_shared",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg_state"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "anyhow",
  "cid",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_shared"
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 dependencies = [
  "anyhow",
  "cid",
@@ -953,7 +953,7 @@ dependencies = [
  "fvm_shared 4.1.2",
  "hex",
  "integer-encoding",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "multihash",
  "num",
  "num-bigint",
@@ -1485,6 +1485,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "10.0.0-dev.4"
+version = "10.0.0-dev.5"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ChainSafe/fil-actor-states"
 authors = [
@@ -36,7 +36,7 @@ keywords = ["filecoin", "web3", "wasm"]
 [workspace.dependencies]
 ahash = "0.8"
 anyhow = "1.0"
-base64 = "0.21.2"
+base64 = "0.22"
 bitflags = "2.4.2"
 byteorder = "1.4.3"
 cid = { version = "0.10", default-features = false, features = ["std"] }
@@ -55,7 +55,7 @@ hex = "0.4.3"
 hex-literal = "0.4"
 indexmap = { version = "2", features = ["serde"] }
 integer-encoding = { version = "4", default-features = false }
-itertools = "0.11"
+itertools = "0.12"
 lazy_static = "1.4"
 libipld-core = "0.16"
 log = "0.4"

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 keywords.workspace = true
 
 [dependencies]
-fil_actors_shared = { version = "10.0.0-dev.4", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.0.0-dev.5", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 frc46_token = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 
 [dependencies]
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0-dev.4", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.0.0-dev.5", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared3 = { workspace = true }

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0-dev.4", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.0.0-dev.5", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -14,8 +14,8 @@ arb = ["dep:quickcheck"]
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actor_verifreg_state = { version = "10.0.0-dev.4", path = "../verifreg" }
-fil_actors_shared = { version = "10.0.0-dev.4", path = "../../fil_actors_shared" }
+fil_actor_verifreg_state = { version = "10.0.0-dev.5", path = "../verifreg" }
+fil_actors_shared = { version = "10.0.0-dev.5", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_bitfield = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -17,8 +17,8 @@ crate-type = ["cdylib", "lib"]
 anyhow = { workspace = true }
 bitflags = { workspace = true }
 cid = { workspace = true }
-fil_actor_verifreg_state = { version = "10.0.0-dev.4", path = "../verifreg" }
-fil_actors_shared = { version = "10.0.0-dev.4", path = "../../fil_actors_shared" }
+fil_actor_verifreg_state = { version = "10.0.0-dev.5", path = "../verifreg" }
+fil_actors_shared = { version = "10.0.0-dev.5", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 fvm_ipld_bitfield = { workspace = true }

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0-dev.4", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.0.0-dev.5", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 
 [dependencies]
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0-dev.4", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.0.0-dev.5", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0-dev.4", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.0.0-dev.5", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0-dev.4", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.0.0-dev.5", path = "../../fil_actors_shared" }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0-dev.4", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.0.0-dev.5", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/fil_actor_interface/Cargo.toml
+++ b/fil_actor_interface/Cargo.toml
@@ -9,19 +9,19 @@ version.workspace = true
 keywords.workspace = true
 
 [dependencies]
-fil_actor_account_state = { version = "10.0.0-dev.4", path = "../actors/account" }
-fil_actor_cron_state = { version = "10.0.0-dev.4", path = "../actors/cron" }
-fil_actor_datacap_state = { version = "10.0.0-dev.4", path = "../actors/datacap" }
-fil_actor_evm_state = { version = "10.0.0-dev.4", path = "../actors/evm" }
-fil_actor_init_state = { version = "10.0.0-dev.4", path = "../actors/init" }
-fil_actor_market_state = { version = "10.0.0-dev.4", path = "../actors/market" }
-fil_actor_miner_state = { version = "10.0.0-dev.4", path = "../actors/miner" }
-fil_actor_multisig_state = { version = "10.0.0-dev.4", path = "../actors/multisig" }
-fil_actor_power_state = { version = "10.0.0-dev.4", path = "../actors/power" }
-fil_actor_reward_state = { version = "10.0.0-dev.4", path = "../actors/reward" }
-fil_actor_system_state = { version = "10.0.0-dev.4", path = "../actors/system" }
-fil_actor_verifreg_state = { version = "10.0.0-dev.4", path = "../actors/verifreg" }
-fil_actors_shared = { version = "10.0.0-dev.4", path = "../fil_actors_shared" }
+fil_actor_account_state = { version = "10.0.0-dev.5", path = "../actors/account" }
+fil_actor_cron_state = { version = "10.0.0-dev.5", path = "../actors/cron" }
+fil_actor_datacap_state = { version = "10.0.0-dev.5", path = "../actors/datacap" }
+fil_actor_evm_state = { version = "10.0.0-dev.5", path = "../actors/evm" }
+fil_actor_init_state = { version = "10.0.0-dev.5", path = "../actors/init" }
+fil_actor_market_state = { version = "10.0.0-dev.5", path = "../actors/market" }
+fil_actor_miner_state = { version = "10.0.0-dev.5", path = "../actors/miner" }
+fil_actor_multisig_state = { version = "10.0.0-dev.5", path = "../actors/multisig" }
+fil_actor_power_state = { version = "10.0.0-dev.5", path = "../actors/power" }
+fil_actor_reward_state = { version = "10.0.0-dev.5", path = "../actors/reward" }
+fil_actor_system_state = { version = "10.0.0-dev.5", path = "../actors/system" }
+fil_actor_verifreg_state = { version = "10.0.0-dev.5", path = "../actors/verifreg" }
+fil_actors_shared = { version = "10.0.0-dev.5", path = "../fil_actors_shared" }
 
 anyhow.workspace = true
 cid.workspace = true


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Include https://github.com/ChainSafe/fil-actor-states/pull/267 to unblock https://github.com/ChainSafe/forest/pull/4079
- bump `base64` and `itertools` to match their versions in `forest`


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->