### PR TITLE
chore: bump rust-toolchain to match forest

### DIFF
--- a/fil_actors_shared/src/v12/util/map.rs
+++ b/fil_actors_shared/src/v12/util/map.rs
@@ -172,10 +172,11 @@ where
         // wrapped in a hamt::Error::Dynamic.
         F: FnMut(K, &V) -> Result<(), ActorError>,
     {
-        match self.hamt.for_each(|k, v| {
+        let handler = |k: &hamt::BytesKey, v: &V| {
             let key = K::from_bytes(k).context_code(ExitCode::USR_ILLEGAL_STATE, "invalid key")?;
             f(key, v).map_err(|e| anyhow!(e))
-        }) {
+        };
+        match self.hamt.for_each(handler) {
             Ok(_) => Ok(()),
             Err(hamt_err) => match hamt_err {
                 hamt::Error::Dynamic(e) => match e.downcast::<ActorError>() {

--- a/fil_actors_shared/src/v13/util/map.rs
+++ b/fil_actors_shared/src/v13/util/map.rs
@@ -174,10 +174,11 @@ where
         // wrapped in a hamt::Error::Dynamic.
         F: FnMut(K, &V) -> Result<(), ActorError>,
     {
-        match self.hamt.for_each(|k, v| {
+        let handler = |k: &hamt::BytesKey, v: &V| {
             let key = K::from_bytes(k).context_code(ExitCode::USR_ILLEGAL_STATE, "invalid key")?;
             f(key, v).map_err(|e| anyhow!(e))
-        }) {
+        };
+        match self.hamt.for_each(handler) {
             Ok(_) => Ok(()),
             Err(hamt_err) => match hamt_err {
                 hamt::Error::Dynamic(e) => match e.downcast::<ActorError>() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = []


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- bump rust-toolchain to `1.76.0` to match forest



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->