### PR TITLE
fix(ci): setup sccache env var properly in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
       - v*
 env:
   RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
   push:
     tags:
-    - v*
+      - v*
+env:
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   publish:


### PR DESCRIPTION
**Summary of changes**

The `publish crates` job should not take ~15mins (https://github.com/ChainSafe/fil-actor-states/actions/workflows/publish.yml)

Changes introduced in this pull request:
- `sccache` was not working without `RUSTC_WRAPPER=sccache` 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->
https://github.com/Mozilla-Actions/sccache-action?tab=readme-ov-file#rust-code


<!-- Thank you 🔥 -->