### PR TITLE
chore(toolchain): bump rust toolchain to 1.77.0

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,3 +1,5 @@
+exclude = ["forest/**/*.toml"]
+
 [formatting]
 allowed_blank_lines = 1
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.77.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = []


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

- bump rust toolchain to 1.77.0
- update forest submodule
- update taplo config to ignore forest submodule



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->