### PR TITLE
Prepare release 10.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "frc42_macros",
  "fvm_ipld_encoding",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared 2.6.0",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_datacap_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "fil_actors_shared",
  "frc42_macros",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_eam_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "fvm_shared 3.6.0",
  "fvm_shared 4.1.2",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_ethaccount_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared 3.6.0",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_evm_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "cid",
  "fil_actors_shared",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_interface"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "anyhow",
  "bitflags 2.4.2",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "cid",
  "fil_actors_shared",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "fvm_ipld_encoding",
  "fvm_shared 2.6.0",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "cid",
  "fil_actors_shared",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg_state"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "anyhow",
  "cid",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_shared"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "anyhow",
  "cid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "10.0.0"
+version = "10.1.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ChainSafe/fil-actor-states"
 authors = [

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 keywords.workspace = true
 
 [dependencies]
-fil_actors_shared = { version = "10.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.1.0", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 frc46_token = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 
 [dependencies]
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.1.0", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared3 = { workspace = true }

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.1.0", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -14,8 +14,8 @@ arb = ["dep:quickcheck"]
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actor_verifreg_state = { version = "10.0.0", path = "../verifreg" }
-fil_actors_shared = { version = "10.0.0", path = "../../fil_actors_shared" }
+fil_actor_verifreg_state = { version = "10.1.0", path = "../verifreg" }
+fil_actors_shared = { version = "10.1.0", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_bitfield = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -17,8 +17,8 @@ crate-type = ["cdylib", "lib"]
 anyhow = { workspace = true }
 bitflags = { workspace = true }
 cid = { workspace = true }
-fil_actor_verifreg_state = { version = "10.0.0", path = "../verifreg" }
-fil_actors_shared = { version = "10.0.0", path = "../../fil_actors_shared" }
+fil_actor_verifreg_state = { version = "10.1.0", path = "../verifreg" }
+fil_actors_shared = { version = "10.1.0", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 fvm_ipld_bitfield = { workspace = true }

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.1.0", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 
 [dependencies]
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.1.0", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.1.0", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.1.0", path = "../../fil_actors_shared" }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actors_shared = { version = "10.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { version = "10.1.0", path = "../../fil_actors_shared" }
 frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/fil_actor_interface/Cargo.toml
+++ b/fil_actor_interface/Cargo.toml
@@ -9,19 +9,19 @@ version.workspace = true
 keywords.workspace = true
 
 [dependencies]
-fil_actor_account_state = { version = "10.0.0", path = "../actors/account" }
-fil_actor_cron_state = { version = "10.0.0", path = "../actors/cron" }
-fil_actor_datacap_state = { version = "10.0.0", path = "../actors/datacap" }
-fil_actor_evm_state = { version = "10.0.0", path = "../actors/evm" }
-fil_actor_init_state = { version = "10.0.0", path = "../actors/init" }
-fil_actor_market_state = { version = "10.0.0", path = "../actors/market" }
-fil_actor_miner_state = { version = "10.0.0", path = "../actors/miner" }
-fil_actor_multisig_state = { version = "10.0.0", path = "../actors/multisig" }
-fil_actor_power_state = { version = "10.0.0", path = "../actors/power" }
-fil_actor_reward_state = { version = "10.0.0", path = "../actors/reward" }
-fil_actor_system_state = { version = "10.0.0", path = "../actors/system" }
-fil_actor_verifreg_state = { version = "10.0.0", path = "../actors/verifreg" }
-fil_actors_shared = { version = "10.0.0", path = "../fil_actors_shared" }
+fil_actor_account_state = { version = "10.1.0", path = "../actors/account" }
+fil_actor_cron_state = { version = "10.1.0", path = "../actors/cron" }
+fil_actor_datacap_state = { version = "10.1.0", path = "../actors/datacap" }
+fil_actor_evm_state = { version = "10.1.0", path = "../actors/evm" }
+fil_actor_init_state = { version = "10.1.0", path = "../actors/init" }
+fil_actor_market_state = { version = "10.1.0", path = "../actors/market" }
+fil_actor_miner_state = { version = "10.1.0", path = "../actors/miner" }
+fil_actor_multisig_state = { version = "10.1.0", path = "../actors/multisig" }
+fil_actor_power_state = { version = "10.1.0", path = "../actors/power" }
+fil_actor_reward_state = { version = "10.1.0", path = "../actors/reward" }
+fil_actor_system_state = { version = "10.1.0", path = "../actors/system" }
+fil_actor_verifreg_state = { version = "10.1.0", path = "../actors/verifreg" }
+fil_actors_shared = { version = "10.1.0", path = "../fil_actors_shared" }
 
 anyhow.workspace = true
 cid.workspace = true

--- a/fil_actor_interface/builtin_actors_gen.go
+++ b/fil_actor_interface/builtin_actors_gen.go
@@ -249,8 +249,8 @@ var EmbeddedBuiltinActorsMetadata []*BuiltinActorsMetadata = []*BuiltinActorsMet
 }, {
 	Network:      "calibrationnet",
 	Version:      13,
-	BundleGitTag: "v13.0.0-rc.3",
-	ManifestCid:  MustParseCid("bafy2bzacea4firkyvt2zzdwqjrws5pyeluaesh6uaid246tommayr4337xpmi"),
+	BundleGitTag: "v13.0.0",
+	ManifestCid:  MustParseCid("bafy2bzacect4ktyujrwp6mjlsitnpvuw2pbuppz6w52sfljyo4agjevzm75qs"),
 	Actors: map[string]cid.Cid{
 		"account":          MustParseCid("bafk2bzaceb3j36ri5y5mfklgp5emlvrms6g4733ss2j3l7jismrxq6ng3tcc6"),
 		"cron":             MustParseCid("bafk2bzaceaz6rocamdxehgpwcbku6wlapwpgzyyvkrploj66mlqptsulf52bs"),
@@ -267,7 +267,7 @@ var EmbeddedBuiltinActorsMetadata []*BuiltinActorsMetadata = []*BuiltinActorsMet
 		"storageminer":     MustParseCid("bafk2bzaceckzw3v7wqliyggvjvihz4wywchnnsie4frfvkm3fm5znb64mofri"),
 		"storagepower":     MustParseCid("bafk2bzacea7t4wynzjajl442mpdqbnh3wusjusqtnzgpvefvweh4n2tgzgqhu"),
 		"system":           MustParseCid("bafk2bzacedjnrb5glewazsxpcx6rwiuhl4kwrfcqolyprn6rrjtlzmthlhdq6"),
-		"verifiedregistry": MustParseCid("bafk2bzacednskl3bykz5qpo54z2j2p4q44t5of4ktd6vs6ymmg2zebsbxazkm"),
+		"verifiedregistry": MustParseCid("bafk2bzacebj2zdquagzy2xxn7up574oemg3w7ed3fe4aujkyhgdwj57voesn2"),
 	},
 }, {
 	Network: "caterpillarnet",

--- a/fil_actor_interface/src/builtin/miner/mod.rs
+++ b/fil_actor_interface/src/builtin/miner/mod.rs
@@ -65,21 +65,7 @@ pub fn is_v12_miner_cid(cid: &Cid) -> bool {
 }
 
 pub fn is_v13_miner_cid(cid: &Cid) -> bool {
-    // The following code cids existed temporarily on the calibnet testnet, as a "buggy" storage miner actor implementation.
-    // See corresponding Lotus PR: https://github.com/filecoin-project/lotus/pull/11363
-    lazy_static! {
-        static ref V13_POSSIBLE_MINERS: Vec<Cid> = {
-            let cids = vec![
-                // Calibnet
-                // Devnet
-            ];
-
-            cids.into_iter()
-                .filter_map(|s| Cid::from_str(s).ok())
-                .collect()
-        };
-    }
-    crate::KNOWN_CIDS.actor.miner.v13.contains(cid) || V13_POSSIBLE_MINERS.contains(cid)
+    crate::KNOWN_CIDS.actor.miner.v13.contains(cid)
 }
 
 /// Miner actor state.

--- a/fil_actor_interface/src/builtin/verifreg/mod.rs
+++ b/fil_actor_interface/src/builtin/verifreg/mod.rs
@@ -11,6 +11,7 @@ use fvm_shared::address::{Address, Protocol};
 use fvm_shared4::bigint::bigint_ser::BigIntDe;
 use num::BigInt;
 use serde::Serialize;
+use std::str::FromStr;
 
 /// verifreg actor address.
 pub const ADDRESS: Address = Address::new_id(6);
@@ -48,7 +49,14 @@ pub fn is_v12_verifreg_cid(cid: &Cid) -> bool {
 }
 
 pub fn is_v13_verifreg_cid(cid: &Cid) -> bool {
-    crate::KNOWN_CIDS.actor.verifreg.v13.contains(cid)
+    // The following CID existed in the NV22 network, but was fixed as a patch.
+    // See corresponding Lotus PR: https://github.com/filecoin-project/lotus/pull/11776
+    lazy_static::lazy_static! {
+        static ref PATCH_VERIFREG_V13: Cid =
+            Cid::from_str("bafk2bzacednskl3bykz5qpo54z2j2p4q44t5of4ktd6vs6ymmg2zebsbxazkm")
+                .expect("hardcoded CID must be valid");
+    }
+    crate::KNOWN_CIDS.actor.verifreg.v13.contains(cid) || cid == &*PATCH_VERIFREG_V13
 }
 
 impl State {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- prepare release v10.1.0 for the calibration network patch
- added new cids for v13.0.0,
- added old verifreg as exception (same as we did with miner back with watermelon fixes)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->