### PR TITLE
[Fix] Don't consume on reward state on this_epoch_baseline_power.

### DIFF
--- a/fil_actor_interface/src/builtin/reward/mod.rs
+++ b/fil_actor_interface/src/builtin/reward/mod.rs
@@ -114,15 +114,17 @@ impl State {
         }
     }
 
-    /// The baseline power the network is targeting at this state's epoch.
-    pub fn this_epoch_baseline_power(self) -> StoragePower {
+    /// The baseline power the network is targeting at this state's epoch. This needs to be cloned
+    /// as the value is later used in e.g. `deal_provider_collateral_bounds` and would otherwise
+    /// require loading the state twice.
+    pub fn this_epoch_baseline_power(&self) -> StoragePower {
         match self {
-            State::V8(st) => st.this_epoch_baseline_power,
-            State::V9(st) => st.this_epoch_baseline_power,
-            State::V10(st) => st.this_epoch_baseline_power,
-            State::V11(st) => st.this_epoch_baseline_power,
-            State::V12(st) => st.this_epoch_baseline_power,
-            State::V13(st) => st.this_epoch_baseline_power,
+            State::V8(st) => st.this_epoch_baseline_power.clone(),
+            State::V9(st) => st.this_epoch_baseline_power.clone(),
+            State::V10(st) => st.this_epoch_baseline_power.clone(),
+            State::V11(st) => st.this_epoch_baseline_power.clone(),
+            State::V12(st) => st.this_epoch_baseline_power.clone(),
+            State::V13(st) => st.this_epoch_baseline_power.clone(),
         }
     }
 

--- a/fil_actor_interface/src/builtin/reward/mod.rs
+++ b/fil_actor_interface/src/builtin/reward/mod.rs
@@ -189,8 +189,8 @@ impl State {
                 let (min, max) = deal_provider_collateral_bounds_v11(
                     &from_policy_v10_to_v11(policy),
                     from_padded_piece_size_v2_to_v3(size),
-                    &raw_byte_power,
-                    &baseline_power,
+                    raw_byte_power,
+                    baseline_power,
                     &from_token_v2_to_v3(network_circulating_supply),
                 );
                 (from_token_v3_to_v2(min), from_token_v3_to_v2(max))
@@ -199,8 +199,8 @@ impl State {
                 let (min, max) = deal_provider_collateral_bounds_v12(
                     &from_policy_v10_to_v12(policy),
                     from_padded_piece_size_v2_to_v4(size),
-                    &raw_byte_power,
-                    &baseline_power,
+                    raw_byte_power,
+                    baseline_power,
                     &from_token_v2_to_v4(network_circulating_supply),
                 );
                 (from_token_v4_to_v2(min), from_token_v4_to_v2(max))
@@ -209,8 +209,8 @@ impl State {
                 let (min, max) = deal_provider_collateral_bounds_v13(
                     &from_policy_v10_to_v13(policy),
                     from_padded_piece_size_v2_to_v4(size),
-                    &raw_byte_power,
-                    &baseline_power,
+                    raw_byte_power,
+                    baseline_power,
                     &from_token_v2_to_v4(network_circulating_supply),
                 );
                 (from_token_v4_to_v2(min), from_token_v4_to_v2(max))

--- a/fil_actor_interface/src/builtin/reward/mod.rs
+++ b/fil_actor_interface/src/builtin/reward/mod.rs
@@ -114,17 +114,15 @@ impl State {
         }
     }
 
-    /// The baseline power the network is targeting at this state's epoch. This needs to be cloned
-    /// as the value is later used in e.g. `deal_provider_collateral_bounds` and would otherwise
-    /// require loading the state twice.
-    pub fn this_epoch_baseline_power(&self) -> StoragePower {
+    /// The baseline power the network is targeting at this state's epoch.
+    pub fn this_epoch_baseline_power(&self) -> &StoragePower {
         match self {
-            State::V8(st) => st.this_epoch_baseline_power.clone(),
-            State::V9(st) => st.this_epoch_baseline_power.clone(),
-            State::V10(st) => st.this_epoch_baseline_power.clone(),
-            State::V11(st) => st.this_epoch_baseline_power.clone(),
-            State::V12(st) => st.this_epoch_baseline_power.clone(),
-            State::V13(st) => st.this_epoch_baseline_power.clone(),
+            State::V8(st) => &st.this_epoch_baseline_power,
+            State::V9(st) => &st.this_epoch_baseline_power,
+            State::V10(st) => &st.this_epoch_baseline_power,
+            State::V11(st) => &st.this_epoch_baseline_power,
+            State::V12(st) => &st.this_epoch_baseline_power,
+            State::V13(st) => &st.this_epoch_baseline_power,
         }
     }
 
@@ -135,8 +133,8 @@ impl State {
         &self,
         policy: &Policy,
         size: PaddedPieceSize,
-        network_raw_power: StoragePower,
-        baseline_power: StoragePower,
+        network_raw_power: &StoragePower,
+        baseline_power: &StoragePower,
         network_circulating_supply: TokenAmount,
     ) -> (TokenAmount, TokenAmount) {
         // minimumProviderCollateral = ProviderCollateralSupplyTarget * normalizedCirculatingSupply
@@ -147,7 +145,7 @@ impl State {
             network_circulating_supply * policy.prov_collateral_percent_supply_num;
         let power_share_num = BigInt::from(size.0);
         let power_share_denom =
-            max(max(&network_raw_power, &baseline_power), &power_share_num).clone();
+            max(max(network_raw_power, baseline_power), &power_share_num).clone();
 
         let num: BigInt = power_share_num * lock_target_num.atto();
         let denom: BigInt = power_share_denom * policy.prov_collateral_percent_supply_denom;
@@ -161,8 +159,8 @@ impl State {
         &self,
         policy: &Policy,
         size: PaddedPieceSize,
-        raw_byte_power: StoragePower,
-        baseline_power: StoragePower,
+        raw_byte_power: &StoragePower,
+        baseline_power: &StoragePower,
         network_circulating_supply: TokenAmount,
     ) -> (TokenAmount, TokenAmount) {
         match self {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Return a pointer to `this_epoch_baseline_power` to make the api more efficient.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->

```rust
    let (min, max) = reward_state.deal_provider_collateral_bounds(
        policy,
        size,
        power_claim.raw_byte_power,
        reward_state. this_epoch_baseline_power(), // <--- This needs to be non-consuming. 
        supply.into(),
    );
```


<!-- Thank you 🔥 -->