### PR TITLE
[Fix] TokenAmount conversions accept a pointer.

### DIFF
--- a/fil_actor_interface/src/builtin/market/mod.rs
+++ b/fil_actor_interface/src/builtin/market/mod.rs
@@ -188,10 +188,10 @@ impl State {
         match self {
             State::V8(st) => st.total_locked(),
             State::V9(st) => st.total_locked(),
-            State::V10(st) => from_token_v3_to_v2(st.get_total_locked()),
-            State::V11(st) => from_token_v3_to_v2(st.get_total_locked()),
-            State::V12(st) => from_token_v4_to_v2(st.get_total_locked()),
-            State::V13(st) => from_token_v4_to_v2(st.get_total_locked()),
+            State::V10(st) => from_token_v3_to_v2(&st.get_total_locked()),
+            State::V11(st) => from_token_v3_to_v2(&st.get_total_locked()),
+            State::V12(st) => from_token_v4_to_v2(&st.get_total_locked()),
+            State::V13(st) => from_token_v4_to_v2(&st.get_total_locked()),
         }
     }
 }
@@ -303,11 +303,9 @@ impl TryFrom<&fil_actor_market_state::v10::DealProposal> for DealProposal {
             },
             start_epoch: deal_proposal.start_epoch,
             end_epoch: deal_proposal.end_epoch,
-            storage_price_per_epoch: from_token_v3_to_v2(
-                deal_proposal.storage_price_per_epoch.clone(),
-            ),
-            provider_collateral: from_token_v3_to_v2(deal_proposal.provider_collateral.clone()),
-            client_collateral: from_token_v3_to_v2(deal_proposal.client_collateral.clone()),
+            storage_price_per_epoch: from_token_v3_to_v2(&deal_proposal.storage_price_per_epoch),
+            provider_collateral: from_token_v3_to_v2(&deal_proposal.provider_collateral),
+            client_collateral: from_token_v3_to_v2(&deal_proposal.client_collateral),
         })
     }
 }
@@ -330,11 +328,9 @@ impl TryFrom<&fil_actor_market_state::v11::DealProposal> for DealProposal {
             },
             start_epoch: deal_proposal.start_epoch,
             end_epoch: deal_proposal.end_epoch,
-            storage_price_per_epoch: from_token_v3_to_v2(
-                deal_proposal.storage_price_per_epoch.clone(),
-            ),
-            provider_collateral: from_token_v3_to_v2(deal_proposal.provider_collateral.clone()),
-            client_collateral: from_token_v3_to_v2(deal_proposal.client_collateral.clone()),
+            storage_price_per_epoch: from_token_v3_to_v2(&deal_proposal.storage_price_per_epoch),
+            provider_collateral: from_token_v3_to_v2(&deal_proposal.provider_collateral),
+            client_collateral: from_token_v3_to_v2(&deal_proposal.client_collateral),
         })
     }
 }
@@ -357,11 +353,9 @@ impl TryFrom<&fil_actor_market_state::v12::DealProposal> for DealProposal {
             },
             start_epoch: deal_proposal.start_epoch,
             end_epoch: deal_proposal.end_epoch,
-            storage_price_per_epoch: from_token_v4_to_v2(
-                deal_proposal.storage_price_per_epoch.clone(),
-            ),
-            provider_collateral: from_token_v4_to_v2(deal_proposal.provider_collateral.clone()),
-            client_collateral: from_token_v4_to_v2(deal_proposal.client_collateral.clone()),
+            storage_price_per_epoch: from_token_v4_to_v2(&deal_proposal.storage_price_per_epoch),
+            provider_collateral: from_token_v4_to_v2(&deal_proposal.provider_collateral),
+            client_collateral: from_token_v4_to_v2(&deal_proposal.client_collateral),
         })
     }
 }
@@ -384,11 +378,9 @@ impl TryFrom<&fil_actor_market_state::v13::DealProposal> for DealProposal {
             },
             start_epoch: deal_proposal.start_epoch,
             end_epoch: deal_proposal.end_epoch,
-            storage_price_per_epoch: from_token_v4_to_v2(
-                deal_proposal.storage_price_per_epoch.clone(),
-            ),
-            provider_collateral: from_token_v4_to_v2(deal_proposal.provider_collateral.clone()),
-            client_collateral: from_token_v4_to_v2(deal_proposal.client_collateral.clone()),
+            storage_price_per_epoch: from_token_v4_to_v2(&deal_proposal.storage_price_per_epoch),
+            provider_collateral: from_token_v4_to_v2(&deal_proposal.provider_collateral),
+            client_collateral: from_token_v4_to_v2(&deal_proposal.client_collateral),
         })
     }
 }

--- a/fil_actor_interface/src/builtin/miner/mod.rs
+++ b/fil_actor_interface/src/builtin/miner/mod.rs
@@ -318,25 +318,25 @@ impl State {
         match self {
             State::V8(st) => st.fee_debt.clone(),
             State::V9(st) => st.fee_debt.clone(),
-            State::V10(st) => from_token_v3_to_v2(st.fee_debt.clone()),
-            State::V11(st) => from_token_v3_to_v2(st.fee_debt.clone()),
-            State::V12(st) => from_token_v4_to_v2(st.fee_debt.clone()),
-            State::V13(st) => from_token_v4_to_v2(st.fee_debt.clone()),
+            State::V10(st) => from_token_v3_to_v2(&st.fee_debt),
+            State::V11(st) => from_token_v3_to_v2(&st.fee_debt),
+            State::V12(st) => from_token_v4_to_v2(&st.fee_debt),
+            State::V13(st) => from_token_v4_to_v2(&st.fee_debt),
         }
     }
 
     /// Unclaimed funds. Actor balance - (locked funds, precommit deposit, ip requirement) Can go negative if the miner is in IP debt.
     pub fn available_balance(&self, balance: &BigInt) -> anyhow::Result<TokenAmount> {
         let balance: TokenAmount = TokenAmount::from_atto(balance.clone());
-        let balance_v3 = from_token_v2_to_v3(balance.clone());
-        let balance_v4 = from_token_v2_to_v4(balance.clone());
+        let balance_v3 = from_token_v2_to_v3(&balance);
+        let balance_v4 = from_token_v2_to_v4(&balance);
         match self {
             State::V8(st) => st.get_available_balance(&balance),
             State::V9(st) => st.get_available_balance(&balance),
-            State::V10(st) => Ok(from_token_v3_to_v2(st.get_available_balance(&balance_v3)?)),
-            State::V11(st) => Ok(from_token_v3_to_v2(st.get_available_balance(&balance_v3)?)),
-            State::V12(st) => Ok(from_token_v4_to_v2(st.get_available_balance(&balance_v4)?)),
-            State::V13(st) => Ok(from_token_v4_to_v2(st.get_available_balance(&balance_v4)?)),
+            State::V10(st) => Ok(from_token_v3_to_v2(&st.get_available_balance(&balance_v3)?)),
+            State::V11(st) => Ok(from_token_v3_to_v2(&st.get_available_balance(&balance_v3)?)),
+            State::V12(st) => Ok(from_token_v4_to_v2(&st.get_available_balance(&balance_v4)?)),
+            State::V13(st) => Ok(from_token_v4_to_v2(&st.get_available_balance(&balance_v4)?)),
         }
     }
 
@@ -439,13 +439,13 @@ impl From<fil_actor_miner_state::v9::MinerInfo> for MinerInfo {
             beneficiary: info.beneficiary,
             beneficiary_term: BeneficiaryTerm {
                 expiration: info.beneficiary_term.expiration,
-                quota: from_token_v2_to_v4(info.beneficiary_term.quota),
-                used_quota: from_token_v2_to_v4(info.beneficiary_term.used_quota),
+                quota: from_token_v2_to_v4(&info.beneficiary_term.quota),
+                used_quota: from_token_v2_to_v4(&info.beneficiary_term.used_quota),
             },
             pending_beneficiary_term: info.pending_beneficiary_term.map(|term| {
                 PendingBeneficiaryChange {
                     new_beneficiary: from_address_v2_to_v4(term.new_beneficiary),
-                    new_quota: from_token_v2_to_v4(term.new_quota),
+                    new_quota: from_token_v2_to_v4(&term.new_quota),
                     new_expiration: term.new_expiration,
                     approved_by_beneficiary: term.approved_by_beneficiary,
                     approved_by_nominee: term.approved_by_nominee,
@@ -482,14 +482,14 @@ impl From<fil_actor_miner_state::v10::MinerInfo> for MinerInfo {
             pending_owner_address: info.pending_owner_address.map(from_address_v3_to_v2),
             beneficiary: from_address_v3_to_v2(info.beneficiary),
             beneficiary_term: BeneficiaryTerm {
-                quota: from_token_v3_to_v4(info.beneficiary_term.quota),
-                used_quota: from_token_v3_to_v4(info.beneficiary_term.used_quota),
+                quota: from_token_v3_to_v4(&info.beneficiary_term.quota),
+                used_quota: from_token_v3_to_v4(&info.beneficiary_term.used_quota),
                 expiration: info.beneficiary_term.expiration,
             },
             pending_beneficiary_term: info.pending_beneficiary_term.map(|term| {
                 PendingBeneficiaryChange {
                     new_beneficiary: from_address_v3_to_v4(term.new_beneficiary),
-                    new_quota: from_token_v3_to_v4(term.new_quota),
+                    new_quota: from_token_v3_to_v4(&term.new_quota),
                     new_expiration: term.new_expiration,
                     approved_by_beneficiary: term.approved_by_beneficiary,
                     approved_by_nominee: term.approved_by_nominee,
@@ -526,14 +526,14 @@ impl From<fil_actor_miner_state::v11::MinerInfo> for MinerInfo {
             pending_owner_address: info.pending_owner_address.map(from_address_v3_to_v2),
             beneficiary: from_address_v3_to_v2(info.beneficiary),
             beneficiary_term: BeneficiaryTerm {
-                quota: from_token_v3_to_v4(info.beneficiary_term.quota),
-                used_quota: from_token_v3_to_v4(info.beneficiary_term.used_quota),
+                quota: from_token_v3_to_v4(&info.beneficiary_term.quota),
+                used_quota: from_token_v3_to_v4(&info.beneficiary_term.used_quota),
                 expiration: info.beneficiary_term.expiration,
             },
             pending_beneficiary_term: info.pending_beneficiary_term.map(|change| {
                 PendingBeneficiaryChange {
                     new_beneficiary: from_address_v3_to_v4(change.new_beneficiary),
-                    new_quota: from_token_v3_to_v4(change.new_quota),
+                    new_quota: from_token_v3_to_v4(&change.new_quota),
                     new_expiration: change.new_expiration,
                     approved_by_beneficiary: change.approved_by_beneficiary,
                     approved_by_nominee: change.approved_by_nominee,
@@ -854,11 +854,11 @@ impl From<fil_actor_miner_state::v10::SectorOnChainInfo> for SectorOnChainInfo {
             expiration: info.expiration,
             deal_weight: info.deal_weight,
             verified_deal_weight: info.verified_deal_weight,
-            initial_pledge: from_token_v3_to_v2(info.initial_pledge),
-            expected_day_reward: from_token_v3_to_v2(info.expected_day_reward),
-            expected_storage_pledge: from_token_v3_to_v2(info.expected_storage_pledge),
+            initial_pledge: from_token_v3_to_v2(&info.initial_pledge),
+            expected_day_reward: from_token_v3_to_v2(&info.expected_day_reward),
+            expected_storage_pledge: from_token_v3_to_v2(&info.expected_storage_pledge),
             replaced_sector_age: info.replaced_sector_age,
-            replaced_day_reward: from_token_v3_to_v2(info.replaced_day_reward),
+            replaced_day_reward: from_token_v3_to_v2(&info.replaced_day_reward),
             sector_key_cid: info.sector_key_cid,
             simple_qa_power: info.simple_qa_power,
         }
@@ -876,11 +876,11 @@ impl From<fil_actor_miner_state::v11::SectorOnChainInfo> for SectorOnChainInfo {
             expiration: info.expiration,
             deal_weight: info.deal_weight,
             verified_deal_weight: info.verified_deal_weight,
-            initial_pledge: from_token_v3_to_v2(info.initial_pledge),
-            expected_day_reward: from_token_v3_to_v2(info.expected_day_reward),
-            expected_storage_pledge: from_token_v3_to_v2(info.expected_storage_pledge),
+            initial_pledge: from_token_v3_to_v2(&info.initial_pledge),
+            expected_day_reward: from_token_v3_to_v2(&info.expected_day_reward),
+            expected_storage_pledge: from_token_v3_to_v2(&info.expected_storage_pledge),
             replaced_sector_age: info.replaced_sector_age,
-            replaced_day_reward: from_token_v3_to_v2(info.replaced_day_reward),
+            replaced_day_reward: from_token_v3_to_v2(&info.replaced_day_reward),
             sector_key_cid: info.sector_key_cid,
             simple_qa_power: info.simple_qa_power,
         }
@@ -898,11 +898,11 @@ impl From<fil_actor_miner_state::v12::SectorOnChainInfo> for SectorOnChainInfo {
             expiration: info.expiration,
             deal_weight: info.deal_weight,
             verified_deal_weight: info.verified_deal_weight,
-            initial_pledge: from_token_v4_to_v2(info.initial_pledge),
-            expected_day_reward: from_token_v4_to_v2(info.expected_day_reward),
-            expected_storage_pledge: from_token_v4_to_v2(info.expected_storage_pledge),
+            initial_pledge: from_token_v4_to_v2(&info.initial_pledge),
+            expected_day_reward: from_token_v4_to_v2(&info.expected_day_reward),
+            expected_storage_pledge: from_token_v4_to_v2(&info.expected_storage_pledge),
             replaced_sector_age: ChainEpoch::default(),
-            replaced_day_reward: from_token_v4_to_v2(info.replaced_day_reward),
+            replaced_day_reward: from_token_v4_to_v2(&info.replaced_day_reward),
             sector_key_cid: info.sector_key_cid,
             simple_qa_power: bool::default(),
         }
@@ -920,11 +920,11 @@ impl From<fil_actor_miner_state::v13::SectorOnChainInfo> for SectorOnChainInfo {
             expiration: info.expiration,
             deal_weight: info.deal_weight,
             verified_deal_weight: info.verified_deal_weight,
-            initial_pledge: from_token_v4_to_v2(info.initial_pledge),
-            expected_day_reward: from_token_v4_to_v2(info.expected_day_reward),
-            expected_storage_pledge: from_token_v4_to_v2(info.expected_storage_pledge),
+            initial_pledge: from_token_v4_to_v2(&info.initial_pledge),
+            expected_day_reward: from_token_v4_to_v2(&info.expected_day_reward),
+            expected_storage_pledge: from_token_v4_to_v2(&info.expected_storage_pledge),
             replaced_sector_age: ChainEpoch::default(),
-            replaced_day_reward: from_token_v4_to_v2(info.replaced_day_reward),
+            replaced_day_reward: from_token_v4_to_v2(&info.replaced_day_reward),
             sector_key_cid: info.sector_key_cid,
             simple_qa_power: bool::default(),
         }

--- a/fil_actor_interface/src/builtin/multisig/mod.rs
+++ b/fil_actor_interface/src/builtin/multisig/mod.rs
@@ -106,10 +106,10 @@ impl State {
         Ok(match self {
             State::V8(st) => st.amount_locked(height),
             State::V9(st) => st.amount_locked(height),
-            State::V10(st) => from_token_v3_to_v2(st.amount_locked(height)),
-            State::V11(st) => from_token_v3_to_v2(st.amount_locked(height)),
-            State::V12(st) => from_token_v4_to_v2(st.amount_locked(height)),
-            State::V13(st) => from_token_v4_to_v2(st.amount_locked(height)),
+            State::V10(st) => from_token_v3_to_v2(&st.amount_locked(height)),
+            State::V11(st) => from_token_v3_to_v2(&st.amount_locked(height)),
+            State::V12(st) => from_token_v4_to_v2(&st.amount_locked(height)),
+            State::V13(st) => from_token_v4_to_v2(&st.amount_locked(height)),
         })
     }
 

--- a/fil_actor_interface/src/builtin/power/mod.rs
+++ b/fil_actor_interface/src/builtin/power/mod.rs
@@ -169,10 +169,10 @@ impl State {
         match self {
             State::V8(st) => st.into_total_locked(),
             State::V9(st) => st.into_total_locked(),
-            State::V10(st) => from_token_v3_to_v2(st.into_total_locked()),
-            State::V11(st) => from_token_v3_to_v2(st.into_total_locked()),
-            State::V12(st) => from_token_v4_to_v2(st.into_total_locked()),
-            State::V13(st) => from_token_v4_to_v2(st.into_total_locked()),
+            State::V10(st) => from_token_v3_to_v2(&st.into_total_locked()),
+            State::V11(st) => from_token_v3_to_v2(&st.into_total_locked()),
+            State::V12(st) => from_token_v4_to_v2(&st.into_total_locked()),
+            State::V13(st) => from_token_v4_to_v2(&st.into_total_locked()),
         }
     }
 
@@ -274,10 +274,10 @@ impl State {
         match self {
             State::V8(st) => st.total_pledge_collateral.clone(),
             State::V9(st) => st.total_pledge_collateral.clone(),
-            State::V10(st) => from_token_v3_to_v2(st.total_pledge_collateral.clone()),
-            State::V11(st) => from_token_v3_to_v2(st.total_pledge_collateral.clone()),
-            State::V12(st) => from_token_v4_to_v2(st.total_pledge_collateral.clone()),
-            State::V13(st) => from_token_v4_to_v2(st.total_pledge_collateral.clone()),
+            State::V10(st) => from_token_v3_to_v2(&st.total_pledge_collateral),
+            State::V11(st) => from_token_v3_to_v2(&st.total_pledge_collateral),
+            State::V12(st) => from_token_v4_to_v2(&st.total_pledge_collateral.clone()),
+            State::V13(st) => from_token_v4_to_v2(&st.total_pledge_collateral.clone()),
         }
     }
 }

--- a/fil_actor_interface/src/builtin/reward/mod.rs
+++ b/fil_actor_interface/src/builtin/reward/mod.rs
@@ -107,10 +107,10 @@ impl State {
         match self {
             State::V8(st) => st.into_total_storage_power_reward(),
             State::V9(st) => st.into_total_storage_power_reward(),
-            State::V10(st) => from_token_v3_to_v2(st.into_total_storage_power_reward()),
-            State::V11(st) => from_token_v3_to_v2(st.into_total_storage_power_reward()),
-            State::V12(st) => from_token_v4_to_v2(st.into_total_storage_power_reward()),
-            State::V13(st) => from_token_v4_to_v2(st.into_total_storage_power_reward()),
+            State::V10(st) => from_token_v3_to_v2(&st.into_total_storage_power_reward()),
+            State::V11(st) => from_token_v3_to_v2(&st.into_total_storage_power_reward()),
+            State::V12(st) => from_token_v4_to_v2(&st.into_total_storage_power_reward()),
+            State::V13(st) => from_token_v4_to_v2(&st.into_total_storage_power_reward()),
         }
     }
 
@@ -135,7 +135,7 @@ impl State {
         size: PaddedPieceSize,
         network_raw_power: &StoragePower,
         baseline_power: &StoragePower,
-        network_circulating_supply: TokenAmount,
+        network_circulating_supply: &TokenAmount,
     ) -> (TokenAmount, TokenAmount) {
         // minimumProviderCollateral = ProviderCollateralSupplyTarget * normalizedCirculatingSupply
         // normalizedCirculatingSupply = networkCirculatingSupply * dealPowerShare
@@ -161,7 +161,7 @@ impl State {
         size: PaddedPieceSize,
         raw_byte_power: &StoragePower,
         baseline_power: &StoragePower,
-        network_circulating_supply: TokenAmount,
+        network_circulating_supply: &TokenAmount,
     ) -> (TokenAmount, TokenAmount) {
         match self {
             State::V8(_) => self.deal_provider_collateral_bounds_pre_v11(
@@ -193,7 +193,7 @@ impl State {
                     baseline_power,
                     &from_token_v2_to_v3(network_circulating_supply),
                 );
-                (from_token_v3_to_v2(min), from_token_v3_to_v2(max))
+                (from_token_v3_to_v2(&min), from_token_v3_to_v2(&max))
             }
             State::V12(_) => {
                 let (min, max) = deal_provider_collateral_bounds_v12(
@@ -203,7 +203,7 @@ impl State {
                     baseline_power,
                     &from_token_v2_to_v4(network_circulating_supply),
                 );
-                (from_token_v4_to_v2(min), from_token_v4_to_v2(max))
+                (from_token_v4_to_v2(&min), from_token_v4_to_v2(&max))
             }
             State::V13(_) => {
                 let (min, max) = deal_provider_collateral_bounds_v13(
@@ -213,7 +213,7 @@ impl State {
                     baseline_power,
                     &from_token_v2_to_v4(network_circulating_supply),
                 );
-                (from_token_v4_to_v2(min), from_token_v4_to_v2(max))
+                (from_token_v4_to_v2(&min), from_token_v4_to_v2(&max))
             }
         }
     }

--- a/fil_actor_interface/src/convert.rs
+++ b/fil_actor_interface/src/convert.rs
@@ -83,23 +83,23 @@ pub fn from_address_v4_to_v2(addr: AddressV4) -> AddressV2 {
         .expect("Couldn't convert between FVM4 and FVM2 addresses.")
 }
 
-pub fn from_token_v2_to_v4(token: TokenAmountV2) -> TokenAmountV4 {
+pub fn from_token_v2_to_v4(token: &TokenAmountV2) -> TokenAmountV4 {
     TokenAmountV4::from_atto(token.atto().clone())
 }
 
-pub fn from_token_v3_to_v2(token: TokenAmountV3) -> TokenAmountV2 {
+pub fn from_token_v3_to_v2(token: &TokenAmountV3) -> TokenAmountV2 {
     TokenAmountV2::from_atto(token.atto().clone())
 }
 
-pub fn from_token_v3_to_v4(token: TokenAmountV3) -> TokenAmountV4 {
+pub fn from_token_v3_to_v4(token: &TokenAmountV3) -> TokenAmountV4 {
     TokenAmountV4::from_atto(token.atto().clone())
 }
 
-pub fn from_token_v4_to_v2(token: TokenAmountV4) -> TokenAmountV2 {
+pub fn from_token_v4_to_v2(token: &TokenAmountV4) -> TokenAmountV2 {
     TokenAmountV2::from_atto(token.atto().clone())
 }
 
-pub fn from_token_v2_to_v3(token: TokenAmountV2) -> TokenAmountV3 {
+pub fn from_token_v2_to_v3(token: &TokenAmountV2) -> TokenAmountV3 {
     TokenAmountV3::from_atto(token.atto().clone())
 }
 

--- a/fil_actor_interface/src/macros.rs
+++ b/fil_actor_interface/src/macros.rs
@@ -44,7 +44,7 @@ macro_rules! parse_pending_transactions_v3 {
                     $res.push(Transaction {
                         id: tx_id,
                         to: from_address_v3_to_v2(txn.to),
-                        value: from_token_v3_to_v2(txn.value.clone()),
+                        value: from_token_v3_to_v2(&txn.value),
                         method: txn.method,
                         params: txn.params.clone(),
                         approved: txn
@@ -75,7 +75,7 @@ macro_rules! parse_pending_transactions_v4 {
             $res.push(Transaction {
                 id: tx_id.0,
                 to: from_address_v4_to_v2(txn.to),
-                value: from_token_v4_to_v2(txn.value.clone()),
+                value: from_token_v4_to_v2(&txn.value),
                 method: txn.method,
                 params: txn.params.clone(),
                 approved: txn


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- TokenAmount conversions accept a pointer to avoid extra clone and allow for more eloquent api.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #283 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->