### PR TITLE
chore: no network in policies + use v13 as export

### DIFF
--- a/fil_actor_interface/src/builtin/miner/mod.rs
+++ b/fil_actor_interface/src/builtin/miner/mod.rs
@@ -139,20 +139,22 @@ impl State {
     ) -> anyhow::Result<()> {
         match self {
             State::V8(st) => st.load_deadlines(&store)?.for_each(
-                &from_policy_v10_to_v9(policy),
+                &from_policy_v13_to_v9(policy),
                 &store,
                 |idx, dl| f(idx, Deadline::V8(dl)),
             ),
             State::V9(st) => st.load_deadlines(&store)?.for_each(
-                &from_policy_v10_to_v9(policy),
+                &from_policy_v13_to_v9(policy),
                 &store,
                 |idx, dl| f(idx, Deadline::V9(dl)),
             ),
-            State::V10(st) => st
-                .load_deadlines(&store)?
-                .for_each(policy, &store, |idx, dl| f(idx, Deadline::V10(dl))),
+            State::V10(st) => st.load_deadlines(&store)?.for_each(
+                &from_policy_v13_to_v10(policy),
+                &store,
+                |idx, dl| f(idx, Deadline::V10(dl)),
+            ),
             State::V11(st) => st.load_deadlines(&store)?.for_each(
-                &from_policy_v10_to_v11(policy),
+                &from_policy_v13_to_v11(policy),
                 &store,
                 |idx, dl| f(idx, Deadline::V11(dl)),
             ),
@@ -175,19 +177,19 @@ impl State {
         match self {
             State::V8(st) => Ok(st
                 .load_deadlines(store)?
-                .load_deadline(&from_policy_v10_to_v9(policy), store, idx)
+                .load_deadline(&from_policy_v13_to_v9(policy), store, idx)
                 .map(Deadline::V8)?),
             State::V9(st) => Ok(st
                 .load_deadlines(store)?
-                .load_deadline(&from_policy_v10_to_v9(policy), store, idx)
+                .load_deadline(&from_policy_v13_to_v9(policy), store, idx)
                 .map(Deadline::V9)?),
             State::V10(st) => Ok(st
                 .load_deadlines(store)?
-                .load_deadline(policy, store, idx)
+                .load_deadline(&from_policy_v13_to_v10(policy), store, idx)
                 .map(Deadline::V10)?),
             State::V11(st) => Ok(st
                 .load_deadlines(store)?
-                .load_deadline(&from_policy_v10_to_v11(policy), store, idx)
+                .load_deadline(&from_policy_v13_to_v11(policy), store, idx)
                 .map(Deadline::V11)?),
             State::V12(st) => Ok(st
                 .load_deadlines(store)?
@@ -344,21 +346,21 @@ impl State {
     pub fn deadline_info(&self, policy: &Policy, current_epoch: ChainEpoch) -> DeadlineInfo {
         match self {
             State::V8(st) => st
-                .deadline_info(&from_policy_v10_to_v9(policy), current_epoch)
+                .deadline_info(&from_policy_v13_to_v9(policy), current_epoch)
                 .into(),
             State::V9(st) => st
-                .deadline_info(&from_policy_v10_to_v9(policy), current_epoch)
+                .deadline_info(&from_policy_v13_to_v9(policy), current_epoch)
                 .into(),
-            State::V10(st) => st.deadline_info(policy, current_epoch).into(),
+            State::V10(st) => st
+                .deadline_info(&from_policy_v13_to_v10(policy), current_epoch)
+                .into(),
             State::V11(st) => st
-                .deadline_info(&from_policy_v10_to_v11(policy), current_epoch)
+                .deadline_info(&from_policy_v13_to_v11(policy), current_epoch)
                 .into(),
             State::V12(st) => st
-                .deadline_info(&from_policy_v10_to_v12(policy), current_epoch)
+                .deadline_info(&from_policy_v13_to_v12(policy), current_epoch)
                 .into(),
-            State::V13(st) => st
-                .deadline_info(&from_policy_v10_to_v13(policy), current_epoch)
-                .into(),
+            State::V13(st) => st.deadline_info(policy, current_epoch).into(),
         }
     }
 }

--- a/fil_actor_interface/src/builtin/power/mod.rs
+++ b/fil_actor_interface/src/builtin/power/mod.rs
@@ -209,22 +209,26 @@ impl State {
     ) -> anyhow::Result<bool> {
         match self {
             State::V8(st) => st.miner_nominal_power_meets_consensus_minimum(
-                &from_policy_v10_to_v9(policy),
+                &from_policy_v13_to_v9(policy),
                 &s,
                 miner,
             ),
             State::V9(st) => st.miner_nominal_power_meets_consensus_minimum(
-                &from_policy_v10_to_v9(policy),
+                &from_policy_v13_to_v9(policy),
                 &s,
                 miner,
             ),
             State::V10(st) => st
-                .miner_nominal_power_meets_consensus_minimum(policy, &s, miner.id()?)
+                .miner_nominal_power_meets_consensus_minimum(
+                    &from_policy_v13_to_v10(policy),
+                    &s,
+                    miner.id()?,
+                )
                 .map(|(_, bool_val)| bool_val)
                 .map_err(|e| anyhow::anyhow!("{}", e)),
             State::V11(st) => st
                 .miner_nominal_power_meets_consensus_minimum(
-                    &from_policy_v10_to_v11(policy),
+                    &from_policy_v13_to_v11(policy),
                     &s,
                     miner.id()?,
                 )
@@ -232,18 +236,14 @@ impl State {
                 .map_err(|e| anyhow::anyhow!("{}", e)),
             State::V12(st) => st
                 .miner_nominal_power_meets_consensus_minimum(
-                    &from_policy_v10_to_v12(policy),
+                    &from_policy_v13_to_v12(policy),
                     &s,
                     miner.id()?,
                 )
                 .map(|(_, bool_val)| bool_val)
                 .map_err(|e| anyhow::anyhow!("{}", e)),
             State::V13(st) => st
-                .miner_nominal_power_meets_consensus_minimum(
-                    &from_policy_v10_to_v13(policy),
-                    &s,
-                    miner.id()?,
-                )
+                .miner_nominal_power_meets_consensus_minimum(policy, &s, miner.id()?)
                 .map(|(_, bool_val)| bool_val)
                 .map_err(|e| anyhow::anyhow!("{}", e)),
         }

--- a/fil_actor_interface/src/builtin/reward/mod.rs
+++ b/fil_actor_interface/src/builtin/reward/mod.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::convert::{
-    from_padded_piece_size_v2_to_v3, from_padded_piece_size_v2_to_v4, from_policy_v10_to_v11,
-    from_policy_v10_to_v12, from_policy_v10_to_v13, from_token_v2_to_v3, from_token_v2_to_v4,
-    from_token_v3_to_v2, from_token_v4_to_v2,
+    from_padded_piece_size_v2_to_v3, from_padded_piece_size_v2_to_v4, from_policy_v13_to_v11,
+    from_policy_v13_to_v12, from_token_v2_to_v3, from_token_v2_to_v4, from_token_v3_to_v2,
+    from_token_v4_to_v2,
 };
 use crate::io::get_obj;
 use anyhow::Context;
@@ -24,7 +24,7 @@ use num::BigInt;
 use serde::Serialize;
 use std::cmp::max;
 
-use fil_actors_shared::v10::runtime::Policy;
+use crate::Policy;
 
 /// Reward actor address.
 pub const ADDRESS: Address = Address::new_id(2);
@@ -227,7 +227,7 @@ impl State {
             ),
             State::V11(_) => {
                 let (min, max) = deal_provider_collateral_bounds_v11(
-                    &from_policy_v10_to_v11(policy),
+                    &from_policy_v13_to_v11(policy),
                     from_padded_piece_size_v2_to_v3(size),
                     raw_byte_power,
                     baseline_power,
@@ -237,7 +237,7 @@ impl State {
             }
             State::V12(_) => {
                 let (min, max) = deal_provider_collateral_bounds_v12(
-                    &from_policy_v10_to_v12(policy),
+                    &from_policy_v13_to_v12(policy),
                     from_padded_piece_size_v2_to_v4(size),
                     raw_byte_power,
                     baseline_power,
@@ -247,7 +247,7 @@ impl State {
             }
             State::V13(_) => {
                 let (min, max) = deal_provider_collateral_bounds_v13(
-                    &from_policy_v10_to_v13(policy),
+                    policy,
                     from_padded_piece_size_v2_to_v4(size),
                     raw_byte_power,
                     baseline_power,

--- a/fil_actor_interface/src/convert.rs
+++ b/fil_actor_interface/src/convert.rs
@@ -4,11 +4,9 @@
 use fil_actors_shared::v10::runtime::Policy as PolicyV10;
 use fil_actors_shared::v11::runtime::Policy as PolicyV11;
 use fil_actors_shared::v11::runtime::ProofSet as ProofSetV11;
-use fil_actors_shared::v12::runtime::policy_constants;
 use fil_actors_shared::v12::runtime::Policy as PolicyV12;
 use fil_actors_shared::v12::runtime::ProofSet as ProofSetV12;
 use fil_actors_shared::v13::runtime::Policy as PolicyV13;
-use fil_actors_shared::v13::runtime::ProofSet as ProofSetV13;
 use fil_actors_shared::v9::runtime::Policy as PolicyV9;
 use fvm_shared::address::Address as AddressV2;
 use fvm_shared::econ::TokenAmount as TokenAmountV2;
@@ -147,7 +145,25 @@ pub fn from_filter_estimate_v4_to_v2(fe: FilterEstimateV4) -> FilterEstimateV2 {
     }
 }
 
-pub fn from_policy_v10_to_v9(policy: &PolicyV10) -> PolicyV9 {
+pub fn from_policy_v13_to_v9(policy: &PolicyV13) -> PolicyV9 {
+    let valid_post_proof_type = policy
+        .valid_post_proof_type
+        .clone()
+        .into_inner()
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &p)| if p { Some((i as i64).into()) } else { None })
+        .collect();
+
+    let valid_pre_commit_proof_type = policy
+        .valid_pre_commit_proof_type
+        .clone()
+        .into_inner()
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &p)| if p { Some((i as i64).into()) } else { None })
+        .collect();
+
     PolicyV9 {
         max_aggregated_sectors: policy.max_aggregated_sectors,
         min_aggregated_sectors: policy.min_aggregated_sectors,
@@ -181,16 +197,8 @@ pub fn from_policy_v10_to_v9(policy: &PolicyV10) -> PolicyV9 {
         consensus_fault_ineligibility_duration: policy.consensus_fault_ineligibility_duration,
         new_sectors_per_period_max: policy.new_sectors_per_period_max,
         chain_finality: policy.chain_finality,
-        valid_post_proof_type: policy
-            .valid_post_proof_type
-            .iter()
-            .map(|proof| from_reg_post_proof_v3_to_v2(*proof))
-            .collect(),
-        valid_pre_commit_proof_type: policy
-            .valid_pre_commit_proof_type
-            .iter()
-            .map(|proof| from_reg_seal_proof_v3_to_v2(*proof))
-            .collect(),
+        valid_post_proof_type,
+        valid_pre_commit_proof_type,
         minimum_verified_allocation_size: policy.minimum_verified_allocation_size.clone(),
         minimum_verified_allocation_term: policy.minimum_verified_allocation_term,
         maximum_verified_allocation_term: policy.maximum_verified_allocation_term,
@@ -204,17 +212,90 @@ pub fn from_policy_v10_to_v9(policy: &PolicyV10) -> PolicyV9 {
     }
 }
 
-pub fn from_policy_v10_to_v11(policy: &PolicyV10) -> PolicyV11 {
-    let mut valid_post_proof_type = ProofSetV11::default_post_proofs();
-    let mut valid_pre_commit_proof_type = ProofSetV11::default_post_proofs();
+pub fn from_policy_v13_to_v10(policy: &PolicyV13) -> PolicyV10 {
+    let valid_post_proof_type = policy
+        .valid_post_proof_type
+        .clone()
+        .into_inner()
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &p)| if p { Some((i as i64).into()) } else { None })
+        .collect();
+
+    let valid_pre_commit_proof_type = policy
+        .valid_pre_commit_proof_type
+        .clone()
+        .into_inner()
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &p)| if p { Some((i as i64).into()) } else { None })
+        .collect();
+
+    PolicyV10 {
+        max_aggregated_sectors: policy.max_aggregated_sectors,
+        min_aggregated_sectors: policy.min_aggregated_sectors,
+        max_aggregated_proof_size: policy.max_aggregated_proof_size,
+        max_replica_update_proof_size: policy.max_replica_update_proof_size,
+        pre_commit_sector_batch_max_size: policy.pre_commit_sector_batch_max_size,
+        prove_replica_updates_max_size: policy.prove_replica_updates_max_size,
+        expired_pre_commit_clean_up_delay: policy.expired_pre_commit_clean_up_delay,
+        wpost_proving_period: policy.wpost_proving_period,
+        wpost_challenge_window: policy.wpost_challenge_window,
+        wpost_period_deadlines: policy.wpost_period_deadlines,
+        wpost_max_chain_commit_age: policy.wpost_max_chain_commit_age,
+        wpost_dispute_window: policy.wpost_dispute_window,
+        sectors_max: policy.sectors_max,
+        max_partitions_per_deadline: policy.max_partitions_per_deadline,
+        max_control_addresses: policy.max_control_addresses,
+        max_peer_id_length: policy.max_peer_id_length,
+        max_multiaddr_data: policy.max_multiaddr_data,
+        addressed_partitions_max: policy.addressed_partitions_max,
+        declarations_max: policy.declarations_max,
+        addressed_sectors_max: policy.addressed_sectors_max,
+        max_pre_commit_randomness_lookback: policy.max_pre_commit_randomness_lookback,
+        pre_commit_challenge_delay: policy.pre_commit_challenge_delay,
+        wpost_challenge_lookback: policy.wpost_challenge_lookback,
+        fault_declaration_cutoff: policy.fault_declaration_cutoff,
+        fault_max_age: policy.fault_max_age,
+        worker_key_change_delay: policy.worker_key_change_delay,
+        min_sector_expiration: policy.min_sector_expiration,
+        max_sector_expiration_extension: policy.max_sector_expiration_extension,
+        deal_limit_denominator: policy.deal_limit_denominator,
+        consensus_fault_ineligibility_duration: policy.consensus_fault_ineligibility_duration,
+        new_sectors_per_period_max: policy.new_sectors_per_period_max,
+        chain_finality: policy.chain_finality,
+        valid_post_proof_type,
+        valid_pre_commit_proof_type,
+        minimum_verified_allocation_size: policy.minimum_verified_allocation_size.clone(),
+        minimum_verified_allocation_term: policy.minimum_verified_allocation_term,
+        maximum_verified_allocation_term: policy.maximum_verified_allocation_term,
+        maximum_verified_allocation_expiration: policy.maximum_verified_allocation_expiration,
+        end_of_life_claim_drop_period: policy.end_of_life_claim_drop_period,
+        deal_updates_interval: policy.deal_updates_interval,
+        prov_collateral_percent_supply_num: policy.prov_collateral_percent_supply_num,
+        prov_collateral_percent_supply_denom: policy.prov_collateral_percent_supply_denom,
+        market_default_allocation_term_buffer: policy.market_default_allocation_term_buffer,
+        minimum_consensus_power: policy.minimum_consensus_power.clone(),
+    }
+}
+
+pub fn from_policy_v13_to_v11(policy: &PolicyV13) -> PolicyV11 {
+    let mut valid_post_proof_type = ProofSetV11::default();
     policy
         .valid_post_proof_type
+        .clone()
+        .into_inner()
         .iter()
         .for_each(|proof| valid_post_proof_type.insert(*proof));
+
+    let mut valid_pre_commit_proof_type = ProofSetV11::default();
     policy
         .valid_pre_commit_proof_type
+        .clone()
+        .into_inner()
         .iter()
         .for_each(|proof| valid_pre_commit_proof_type.insert(*proof));
+
     PolicyV11 {
         max_aggregated_sectors: policy.max_aggregated_sectors,
         min_aggregated_sectors: policy.min_aggregated_sectors,
@@ -263,17 +344,23 @@ pub fn from_policy_v10_to_v11(policy: &PolicyV10) -> PolicyV11 {
     }
 }
 
-pub fn from_policy_v10_to_v12(policy: &PolicyV10) -> PolicyV12 {
-    let mut valid_post_proof_type = ProofSetV12::default_post_proofs();
-    let mut valid_pre_commit_proof_type = ProofSetV12::default_post_proofs();
+pub fn from_policy_v13_to_v12(policy: &PolicyV13) -> PolicyV12 {
+    let mut valid_post_proof_type = ProofSetV12::default();
     policy
         .valid_post_proof_type
+        .clone()
+        .into_inner()
         .iter()
         .for_each(|proof| valid_post_proof_type.insert(*proof));
+
+    let mut valid_pre_commit_proof_type = ProofSetV12::default();
     policy
         .valid_pre_commit_proof_type
+        .clone()
+        .into_inner()
         .iter()
         .for_each(|proof| valid_pre_commit_proof_type.insert(*proof));
+
     PolicyV12 {
         max_aggregated_sectors: policy.max_aggregated_sectors,
         min_aggregated_sectors: policy.min_aggregated_sectors,
@@ -295,7 +382,6 @@ pub fn from_policy_v10_to_v12(policy: &PolicyV10) -> PolicyV12 {
         addressed_partitions_max: policy.addressed_partitions_max,
         declarations_max: policy.declarations_max,
         addressed_sectors_max: policy.addressed_sectors_max,
-        posted_partitions_max: policy_constants::POSTED_PARTITIONS_MAX,
         max_pre_commit_randomness_lookback: policy.max_pre_commit_randomness_lookback,
         pre_commit_challenge_delay: policy.pre_commit_challenge_delay,
         wpost_challenge_lookback: policy.wpost_challenge_lookback,
@@ -320,65 +406,6 @@ pub fn from_policy_v10_to_v12(policy: &PolicyV10) -> PolicyV12 {
         prov_collateral_percent_supply_denom: policy.prov_collateral_percent_supply_denom,
         market_default_allocation_term_buffer: policy.market_default_allocation_term_buffer,
         minimum_consensus_power: policy.minimum_consensus_power.clone(),
-    }
-}
-
-pub fn from_policy_v10_to_v13(policy: &PolicyV10) -> PolicyV13 {
-    let mut valid_post_proof_type = ProofSetV13::default_post_proofs();
-    let mut valid_pre_commit_proof_type = ProofSetV13::default_post_proofs();
-    policy
-        .valid_post_proof_type
-        .iter()
-        .for_each(|proof| valid_post_proof_type.insert(*proof));
-    policy
-        .valid_pre_commit_proof_type
-        .iter()
-        .for_each(|proof| valid_pre_commit_proof_type.insert(*proof));
-    PolicyV13 {
-        max_aggregated_sectors: policy.max_aggregated_sectors,
-        min_aggregated_sectors: policy.min_aggregated_sectors,
-        max_aggregated_proof_size: policy.max_aggregated_proof_size,
-        max_replica_update_proof_size: policy.max_replica_update_proof_size,
-        pre_commit_sector_batch_max_size: policy.pre_commit_sector_batch_max_size,
-        prove_replica_updates_max_size: policy.prove_replica_updates_max_size,
-        expired_pre_commit_clean_up_delay: policy.expired_pre_commit_clean_up_delay,
-        wpost_proving_period: policy.wpost_proving_period,
-        wpost_challenge_window: policy.wpost_challenge_window,
-        wpost_period_deadlines: policy.wpost_period_deadlines,
-        wpost_max_chain_commit_age: policy.wpost_max_chain_commit_age,
-        wpost_dispute_window: policy.wpost_dispute_window,
-        sectors_max: policy.sectors_max,
-        max_partitions_per_deadline: policy.max_partitions_per_deadline,
-        max_control_addresses: policy.max_control_addresses,
-        max_peer_id_length: policy.max_peer_id_length,
-        max_multiaddr_data: policy.max_multiaddr_data,
-        addressed_partitions_max: policy.addressed_partitions_max,
-        declarations_max: policy.declarations_max,
-        addressed_sectors_max: policy.addressed_sectors_max,
-        posted_partitions_max: policy_constants::POSTED_PARTITIONS_MAX,
-        max_pre_commit_randomness_lookback: policy.max_pre_commit_randomness_lookback,
-        pre_commit_challenge_delay: policy.pre_commit_challenge_delay,
-        wpost_challenge_lookback: policy.wpost_challenge_lookback,
-        fault_declaration_cutoff: policy.fault_declaration_cutoff,
-        fault_max_age: policy.fault_max_age,
-        worker_key_change_delay: policy.worker_key_change_delay,
-        min_sector_expiration: policy.min_sector_expiration,
-        max_sector_expiration_extension: policy.max_sector_expiration_extension,
-        deal_limit_denominator: policy.deal_limit_denominator,
-        consensus_fault_ineligibility_duration: policy.consensus_fault_ineligibility_duration,
-        new_sectors_per_period_max: policy.new_sectors_per_period_max,
-        chain_finality: policy.chain_finality,
-        valid_post_proof_type,
-        valid_pre_commit_proof_type,
-        minimum_verified_allocation_size: policy.minimum_verified_allocation_size.clone(),
-        minimum_verified_allocation_term: policy.minimum_verified_allocation_term,
-        maximum_verified_allocation_term: policy.maximum_verified_allocation_term,
-        maximum_verified_allocation_expiration: policy.maximum_verified_allocation_expiration,
-        end_of_life_claim_drop_period: policy.end_of_life_claim_drop_period,
-        deal_updates_interval: policy.deal_updates_interval,
-        prov_collateral_percent_supply_num: policy.prov_collateral_percent_supply_num,
-        prov_collateral_percent_supply_denom: policy.prov_collateral_percent_supply_denom,
-        market_default_allocation_term_buffer: policy.market_default_allocation_term_buffer,
-        minimum_consensus_power: policy.minimum_consensus_power.clone(),
+        posted_partitions_max: policy.posted_partitions_max,
     }
 }

--- a/fil_actor_interface/src/lib.rs
+++ b/fil_actor_interface/src/lib.rs
@@ -9,5 +9,5 @@ mod r#mod;
 
 pub use self::builtin::*;
 pub use builtin::ActorCids;
-pub use fil_actors_shared::v10::runtime::Policy;
+pub use fil_actors_shared::v13::runtime::Policy;
 pub use r#mod::NetworkManifest;

--- a/fil_actors_shared/src/v10/runtime/policy.rs
+++ b/fil_actors_shared/src/v10/runtime/policy.rs
@@ -166,8 +166,8 @@ pub struct Policy {
     pub minimum_consensus_power: StoragePower,
 }
 
-impl Policy {
-    pub fn mainnet() -> Self {
+impl Default for Policy {
+    fn default() -> Self {
         Policy {
             max_aggregated_sectors: policy_constants::MAX_AGGREGATED_SECTORS,
             min_aggregated_sectors: policy_constants::MIN_AGGREGATED_SECTORS,
@@ -230,18 +230,7 @@ impl Policy {
             market_default_allocation_term_buffer:
                 policy_constants::MARKET_DEFAULT_ALLOCATION_TERM_BUFFER,
 
-            minimum_consensus_power: StoragePower::from(
-                policy_constants::MAINNET_MINIMUM_CONSENSUS_POWER,
-            ),
-        }
-    }
-
-    pub fn calibnet() -> Self {
-        Policy {
-            minimum_consensus_power: StoragePower::from(
-                policy_constants::CALIBNET_MINIMUM_CONSENSUS_POWER,
-            ),
-            ..Policy::mainnet()
+            minimum_consensus_power: StoragePower::from(policy_constants::MINIMUM_CONSENSUS_POWER),
         }
     }
 }
@@ -388,8 +377,7 @@ pub mod policy_constants {
 
     pub const MARKET_DEFAULT_ALLOCATION_TERM_BUFFER: i64 = 90 * EPOCHS_IN_DAY;
 
-    pub const CALIBNET_MINIMUM_CONSENSUS_POWER: i64 = 32 << 30;
-    pub const MAINNET_MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;
+    pub const MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;
 }
 
 #[cfg(feature = "arb")]

--- a/fil_actors_shared/src/v11/runtime/policy.rs
+++ b/fil_actors_shared/src/v11/runtime/policy.rs
@@ -166,9 +166,9 @@ pub struct Policy {
     pub minimum_consensus_power: StoragePower,
 }
 
-impl Policy {
-    pub fn mainnet() -> Policy {
-        Policy {
+impl Default for Policy {
+    fn default() -> Policy {
+        Self {
             max_aggregated_sectors: policy_constants::MAX_AGGREGATED_SECTORS,
             min_aggregated_sectors: policy_constants::MIN_AGGREGATED_SECTORS,
             max_aggregated_proof_size: policy_constants::MAX_AGGREGATED_PROOF_SIZE,
@@ -223,18 +223,7 @@ impl Policy {
             market_default_allocation_term_buffer:
                 policy_constants::MARKET_DEFAULT_ALLOCATION_TERM_BUFFER,
 
-            minimum_consensus_power: StoragePower::from(
-                policy_constants::MAINNET_MINIMUM_CONSENSUS_POWER,
-            ),
-        }
-    }
-
-    pub fn calibnet() -> Self {
-        Policy {
-            minimum_consensus_power: StoragePower::from(
-                policy_constants::CALIBNET_MINIMUM_CONSENSUS_POWER,
-            ),
-            ..Policy::mainnet()
+            minimum_consensus_power: StoragePower::from(policy_constants::MINIMUM_CONSENSUS_POWER),
         }
     }
 }
@@ -388,8 +377,7 @@ pub mod policy_constants {
 
     pub const MARKET_DEFAULT_ALLOCATION_TERM_BUFFER: i64 = 90 * EPOCHS_IN_DAY;
 
-    pub const CALIBNET_MINIMUM_CONSENSUS_POWER: i64 = 32 << 30;
-    pub const MAINNET_MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;
+    pub const MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;
 }
 
 /// A set indicating which proofs are considered valid, optimised for lookup of a small number of
@@ -398,12 +386,25 @@ pub mod policy_constants {
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct ProofSet(Vec<bool>);
 
+impl Default for ProofSet {
+    fn default() -> Self {
+        ProofSet(vec![
+            false;
+            policy_constants::REGISTERED_POST_PROOF_VARIANTS.max(
+                policy_constants::REGISTERED_SEAL_PROOF_VARIANTS
+            )
+        ])
+    }
+}
+
 impl ProofSet {
     /// Create a `ProofSet` for enabled `RegisteredPoStProof`s
     pub fn default_post_proofs() -> Self {
         let mut proofs = vec![false; policy_constants::REGISTERED_POST_PROOF_VARIANTS];
         proofs[i64::from(RegisteredPoStProof::StackedDRGWindow32GiBV1) as usize] = true;
         proofs[i64::from(RegisteredPoStProof::StackedDRGWindow32GiBV1P1) as usize] = true;
+        proofs[i64::from(RegisteredPoStProof::StackedDRGWindow64GiBV1) as usize] = true;
+        proofs[i64::from(RegisteredPoStProof::StackedDRGWindow64GiBV1P1) as usize] = true;
         ProofSet(proofs)
     }
 
@@ -411,6 +412,7 @@ impl ProofSet {
     pub fn default_seal_proofs() -> Self {
         let mut proofs = vec![false; policy_constants::REGISTERED_SEAL_PROOF_VARIANTS];
         proofs[i64::from(RegisteredSealProof::StackedDRG32GiBV1P1) as usize] = true;
+        proofs[i64::from(RegisteredSealProof::StackedDRG64GiBV1P1) as usize] = true;
         ProofSet(proofs)
     }
 

--- a/fil_actors_shared/src/v12/runtime/policy.rs
+++ b/fil_actors_shared/src/v12/runtime/policy.rs
@@ -156,9 +156,9 @@ pub struct Policy {
     pub minimum_consensus_power: StoragePower,
 }
 
-impl Policy {
-    pub fn mainnet() -> Policy {
-        Policy {
+impl Default for Policy {
+    fn default() -> Policy {
+        Self {
             max_aggregated_sectors: policy_constants::MAX_AGGREGATED_SECTORS,
             min_aggregated_sectors: policy_constants::MIN_AGGREGATED_SECTORS,
             max_aggregated_proof_size: policy_constants::MAX_AGGREGATED_PROOF_SIZE,
@@ -214,29 +214,7 @@ impl Policy {
             market_default_allocation_term_buffer:
                 policy_constants::MARKET_DEFAULT_ALLOCATION_TERM_BUFFER,
 
-            minimum_consensus_power: StoragePower::from(
-                policy_constants::MAINNET_MINIMUM_CONSENSUS_POWER,
-            ),
-        }
-    }
-
-    pub fn calibnet() -> Self {
-        Policy {
-            minimum_consensus_power: StoragePower::from(
-                policy_constants::CALIBNET_MINIMUM_CONSENSUS_POWER,
-            ),
-            ..Policy::mainnet()
-        }
-    }
-
-    pub fn devnet() -> Self {
-        Policy {
-            minimum_consensus_power: policy_constants::DEVNET_MINIMUM_CONSENSUS_POWER.into(),
-            minimum_verified_allocation_size: 256.into(),
-            pre_commit_challenge_delay: 10,
-            valid_post_proof_type: ProofSet::devnet_post_proofs(),
-            valid_pre_commit_proof_type: ProofSet::devnet_seal_proofs(),
-            ..Policy::mainnet()
+            minimum_consensus_power: StoragePower::from(policy_constants::MINIMUM_CONSENSUS_POWER),
         }
     }
 }
@@ -350,9 +328,7 @@ pub mod policy_constants {
 
     pub const MARKET_DEFAULT_ALLOCATION_TERM_BUFFER: i64 = 90 * EPOCHS_IN_DAY;
 
-    pub const CALIBNET_MINIMUM_CONSENSUS_POWER: i64 = 32 << 30;
-    pub const MAINNET_MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;
-    pub const DEVNET_MINIMUM_CONSENSUS_POWER: i64 = 2048;
+    pub const MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;
 }
 
 /// A set indicating which proofs are considered valid, optimised for lookup of a small number of
@@ -367,21 +343,23 @@ const REGISTERED_POST_PROOF_VARIANTS: usize = 15;
 /// The number of total possible types (enum variants) of RegisteredSealProof
 const REGISTERED_SEAL_PROOF_VARIANTS: usize = 15;
 
+impl Default for ProofSet {
+    fn default() -> Self {
+        ProofSet(vec![
+            false;
+            REGISTERED_POST_PROOF_VARIANTS
+                .max(REGISTERED_SEAL_PROOF_VARIANTS)
+        ])
+    }
+}
+
 impl ProofSet {
     /// Create a `ProofSet` for enabled `RegisteredPoStProof`s
     pub fn default_post_proofs() -> Self {
         let mut proofs = vec![false; REGISTERED_POST_PROOF_VARIANTS];
 
         proofs[i64::from(RegisteredPoStProof::StackedDRGWindow32GiBV1P1) as usize] = true;
-
-        ProofSet(proofs)
-    }
-
-    /// Create a `ProofSet` for enabled `RegisteredPoStProof`s
-    pub fn devnet_post_proofs() -> Self {
-        let mut proofs = vec![false; REGISTERED_POST_PROOF_VARIANTS];
-
-        proofs[i64::from(RegisteredPoStProof::StackedDRGWindow2KiBV1P1) as usize] = true;
+        proofs[i64::from(RegisteredPoStProof::StackedDRGWindow64GiBV1P1) as usize] = true;
 
         ProofSet(proofs)
     }
@@ -393,17 +371,10 @@ impl ProofSet {
         proofs[i64::from(RegisteredSealProof::StackedDRG32GiBV1P1) as usize] = true;
         proofs[i64::from(RegisteredSealProof::StackedDRG32GiBV1P1_Feat_SyntheticPoRep) as usize] =
             true;
-
-        ProofSet(proofs)
-    }
-
-    /// Create a `ProofSet` for enabled `RegisteredSealProof`s
-    pub fn devnet_seal_proofs() -> Self {
-        let mut proofs = vec![false; REGISTERED_SEAL_PROOF_VARIANTS];
-
-        proofs[i64::from(RegisteredSealProof::StackedDRG2KiBV1P1) as usize] = true;
-        proofs[i64::from(RegisteredSealProof::StackedDRG2KiBV1P1_Feat_SyntheticPoRep) as usize] =
+        proofs[i64::from(RegisteredSealProof::StackedDRG64GiBV1P1) as usize] = true;
+        proofs[i64::from(RegisteredSealProof::StackedDRG64GiBV1P1_Feat_SyntheticPoRep) as usize] =
             true;
+
         ProofSet(proofs)
     }
 

--- a/fil_actors_shared/src/v13/runtime/policy.rs
+++ b/fil_actors_shared/src/v13/runtime/policy.rs
@@ -156,9 +156,9 @@ pub struct Policy {
     pub minimum_consensus_power: StoragePower,
 }
 
-impl Policy {
-    pub fn mainnet() -> Policy {
-        Policy {
+impl Default for Policy {
+    fn default() -> Policy {
+        Self {
             max_aggregated_sectors: policy_constants::MAX_AGGREGATED_SECTORS,
             min_aggregated_sectors: policy_constants::MIN_AGGREGATED_SECTORS,
             max_aggregated_proof_size: policy_constants::MAX_AGGREGATED_PROOF_SIZE,
@@ -214,29 +214,7 @@ impl Policy {
             market_default_allocation_term_buffer:
                 policy_constants::MARKET_DEFAULT_ALLOCATION_TERM_BUFFER,
 
-            minimum_consensus_power: StoragePower::from(
-                policy_constants::MAINNET_MINIMUM_CONSENSUS_POWER,
-            ),
-        }
-    }
-
-    pub fn calibnet() -> Self {
-        Policy {
-            minimum_consensus_power: StoragePower::from(
-                policy_constants::CALIBNET_MINIMUM_CONSENSUS_POWER,
-            ),
-            ..Policy::mainnet()
-        }
-    }
-
-    pub fn devnet() -> Self {
-        Policy {
-            minimum_consensus_power: policy_constants::DEVNET_MINIMUM_CONSENSUS_POWER.into(),
-            minimum_verified_allocation_size: 256.into(),
-            pre_commit_challenge_delay: 10,
-            valid_post_proof_type: ProofSet::devnet_post_proofs(),
-            valid_pre_commit_proof_type: ProofSet::devnet_seal_proofs(),
-            ..Policy::mainnet()
+            minimum_consensus_power: StoragePower::from(policy_constants::MINIMUM_CONSENSUS_POWER),
         }
     }
 }
@@ -350,9 +328,7 @@ pub mod policy_constants {
 
     pub const MARKET_DEFAULT_ALLOCATION_TERM_BUFFER: i64 = 90 * EPOCHS_IN_DAY;
 
-    pub const CALIBNET_MINIMUM_CONSENSUS_POWER: i64 = 32 << 30;
-    pub const MAINNET_MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;
-    pub const DEVNET_MINIMUM_CONSENSUS_POWER: i64 = 2 << 10;
+    pub const MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;
 }
 
 /// A set indicating which proofs are considered valid, optimised for lookup of a small number of
@@ -367,21 +343,23 @@ const REGISTERED_POST_PROOF_VARIANTS: usize = 15;
 /// The number of total possible types (enum variants) of RegisteredSealProof
 const REGISTERED_SEAL_PROOF_VARIANTS: usize = 15;
 
+impl Default for ProofSet {
+    fn default() -> Self {
+        ProofSet(vec![
+            false;
+            REGISTERED_POST_PROOF_VARIANTS
+                .max(REGISTERED_SEAL_PROOF_VARIANTS)
+        ])
+    }
+}
+
 impl ProofSet {
     /// Create a `ProofSet` for enabled `RegisteredPoStProof`s
     pub fn default_post_proofs() -> Self {
         let mut proofs = vec![false; REGISTERED_POST_PROOF_VARIANTS];
 
         proofs[i64::from(RegisteredPoStProof::StackedDRGWindow32GiBV1P1) as usize] = true;
-
-        ProofSet(proofs)
-    }
-
-    /// Create a `ProofSet` for enabled `RegisteredPoStProof`s
-    pub fn devnet_post_proofs() -> Self {
-        let mut proofs = vec![false; REGISTERED_POST_PROOF_VARIANTS];
-
-        proofs[i64::from(RegisteredPoStProof::StackedDRGWindow2KiBV1P1) as usize] = true;
+        proofs[i64::from(RegisteredPoStProof::StackedDRGWindow64GiBV1P1) as usize] = true;
 
         ProofSet(proofs)
     }
@@ -393,17 +371,10 @@ impl ProofSet {
         proofs[i64::from(RegisteredSealProof::StackedDRG32GiBV1P1) as usize] = true;
         proofs[i64::from(RegisteredSealProof::StackedDRG32GiBV1P1_Feat_SyntheticPoRep) as usize] =
             true;
-
-        ProofSet(proofs)
-    }
-
-    /// Create a `ProofSet` for enabled `RegisteredSealProof`s
-    pub fn devnet_seal_proofs() -> Self {
-        let mut proofs = vec![false; REGISTERED_SEAL_PROOF_VARIANTS];
-
-        proofs[i64::from(RegisteredSealProof::StackedDRG2KiBV1P1) as usize] = true;
-        proofs[i64::from(RegisteredSealProof::StackedDRG2KiBV1P1_Feat_SyntheticPoRep) as usize] =
+        proofs[i64::from(RegisteredSealProof::StackedDRG64GiBV1P1) as usize] = true;
+        proofs[i64::from(RegisteredSealProof::StackedDRG64GiBV1P1_Feat_SyntheticPoRep) as usize] =
             true;
+
         ProofSet(proofs)
     }
 
@@ -417,5 +388,9 @@ impl ProofSet {
     pub fn insert<P: Into<i64>>(&mut self, proof: P) {
         let index: i64 = proof.into();
         self.0[index as usize] = true;
+    }
+
+    pub fn into_inner(self) -> Vec<bool> {
+        self.0
     }
 }

--- a/fil_actors_shared/src/v9/runtime/policy.rs
+++ b/fil_actors_shared/src/v9/runtime/policy.rs
@@ -166,9 +166,9 @@ pub struct Policy {
     pub minimum_consensus_power: StoragePower,
 }
 
-impl Policy {
-    pub fn mainnet() -> Self {
-        Policy {
+impl Default for Policy {
+    fn default() -> Self {
+        Self {
             max_aggregated_sectors: policy_constants::MAX_AGGREGATED_SECTORS,
             min_aggregated_sectors: policy_constants::MIN_AGGREGATED_SECTORS,
             max_aggregated_proof_size: policy_constants::MAX_AGGREGATED_PROOF_SIZE,
@@ -230,18 +230,7 @@ impl Policy {
             market_default_allocation_term_buffer:
                 policy_constants::MARKET_DEFAULT_ALLOCATION_TERM_BUFFER,
 
-            minimum_consensus_power: StoragePower::from(
-                policy_constants::MAINNET_MINIMUM_CONSENSUS_POWER,
-            ),
-        }
-    }
-
-    pub fn calibnet() -> Self {
-        Policy {
-            minimum_consensus_power: StoragePower::from(
-                policy_constants::CALIBNET_MINIMUM_CONSENSUS_POWER,
-            ),
-            ..Policy::mainnet()
+            minimum_consensus_power: StoragePower::from(policy_constants::MINIMUM_CONSENSUS_POWER),
         }
     }
 }
@@ -388,6 +377,5 @@ pub mod policy_constants {
 
     pub const MARKET_DEFAULT_ALLOCATION_TERM_BUFFER: i64 = 90 * EPOCHS_IN_DAY;
 
-    pub const CALIBNET_MINIMUM_CONSENSUS_POWER: i64 = 32 << 30;
-    pub const MAINNET_MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;
+    pub const MINIMUM_CONSENSUS_POWER: i64 = 10 << 40;
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- :warning: this is a breaking change, a major version bump will be required,
- remove network definitions from the policies - they were incorrect, introduced unnecessary coupling, strived away from the original implementation and were by large re-defined in Forest itself.
- make `v13` policy the default, exported one.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Close


**Other information and links**
<!-- Add any other context about the pull request here. -->
Corresponding Forest PR https://github.com/ChainSafe/forest/pull/4325


<!-- Thank you 🔥 -->