### PR TITLE
feat: add `fn miner::State::get_sector`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "13.0.0"
+version = "13.1.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ChainSafe/fil-actor-states"
 authors = [
@@ -81,5 +81,19 @@ thiserror = "1.0"
 toml = "0.8"
 uint = { version = "0.9.3", default-features = false }
 unsigned-varint = "0.8"
+
+fil_actor_account_state = { version = "13.1.0", path = "./actors/account" }
+fil_actor_cron_state = { version = "13.1.0", path = "./actors/cron" }
+fil_actor_datacap_state = { version = "13.1.0", path = "./actors/datacap" }
+fil_actor_evm_state = { version = "13.1.0", path = "./actors/evm" }
+fil_actor_init_state = { version = "13.1.0", path = "./actors/init" }
+fil_actor_market_state = { version = "13.1.0", path = "./actors/market" }
+fil_actor_miner_state = { version = "13.1.0", path = "./actors/miner" }
+fil_actor_multisig_state = { version = "13.1.0", path = "./actors/multisig" }
+fil_actor_power_state = { version = "13.1.0", path = "./actors/power" }
+fil_actor_reward_state = { version = "13.1.0", path = "./actors/reward" }
+fil_actor_system_state = { version = "13.1.0", path = "./actors/system" }
+fil_actor_verifreg_state = { version = "13.1.0", path = "./actors/verifreg" }
+fil_actors_shared = { version = "13.1.0", path = "./fil_actors_shared" }
 
 fil_actors_test_utils = { path = "./fil_actors_test_utils" }

--- a/actors/datacap/Cargo.toml
+++ b/actors/datacap/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 keywords.workspace = true
 
 [dependencies]
-fil_actors_shared = { version = "13.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { workspace = true }
 frc42_macros = { workspace = true }
 frc46_token = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/actors/evm/Cargo.toml
+++ b/actors/evm/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 
 [dependencies]
 cid = { workspace = true }
-fil_actors_shared = { version = "13.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { workspace = true }
 frc42_macros = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared3 = { workspace = true }

--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actors_shared = { version = "13.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { workspace = true }
 frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -14,8 +14,8 @@ arb = ["dep:quickcheck"]
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actor_verifreg_state = { version = "13.0.0", path = "../verifreg" }
-fil_actors_shared = { version = "13.0.0", path = "../../fil_actors_shared" }
+fil_actor_verifreg_state = { workspace = true }
+fil_actors_shared = { workspace = true }
 frc42_macros = { workspace = true }
 fvm_ipld_bitfield = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -17,8 +17,8 @@ crate-type = ["cdylib", "lib"]
 anyhow = { workspace = true }
 bitflags = { workspace = true }
 cid = { workspace = true }
-fil_actor_verifreg_state = { version = "13.0.0", path = "../verifreg" }
-fil_actors_shared = { version = "13.0.0", path = "../../fil_actors_shared" }
+fil_actor_verifreg_state = { workspace = true }
+fil_actors_shared = { workspace = true }
 frc42_macros = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 fvm_ipld_bitfield = { workspace = true }

--- a/actors/multisig/Cargo.toml
+++ b/actors/multisig/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actors_shared = { version = "13.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { workspace = true }
 frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/actors/paych/Cargo.toml
+++ b/actors/paych/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 
 [dependencies]
 cid = { workspace = true }
-fil_actors_shared = { version = "13.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { workspace = true }
 frc42_macros = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }

--- a/actors/power/Cargo.toml
+++ b/actors/power/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actors_shared = { version = "13.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { workspace = true }
 frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/actors/reward/Cargo.toml
+++ b/actors/reward/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 keywords.workspace = true
 
 [dependencies]
-fil_actor_miner_state = { version = "13.0.0", path = "../miner" }
+fil_actor_miner_state = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_shared3 = { workspace = true }

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 cid = { workspace = true }
-fil_actors_shared = { version = "13.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }

--- a/actors/verifreg/Cargo.toml
+++ b/actors/verifreg/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-fil_actors_shared = { version = "13.0.0", path = "../../fil_actors_shared" }
+fil_actors_shared = { workspace = true }
 frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/fil_actor_interface/Cargo.toml
+++ b/fil_actor_interface/Cargo.toml
@@ -9,19 +9,19 @@ version.workspace = true
 keywords.workspace = true
 
 [dependencies]
-fil_actor_account_state = { version = "13.0.0", path = "../actors/account" }
-fil_actor_cron_state = { version = "13.0.0", path = "../actors/cron" }
-fil_actor_datacap_state = { version = "13.0.0", path = "../actors/datacap" }
-fil_actor_evm_state = { version = "13.0.0", path = "../actors/evm" }
-fil_actor_init_state = { version = "13.0.0", path = "../actors/init" }
-fil_actor_market_state = { version = "13.0.0", path = "../actors/market" }
-fil_actor_miner_state = { version = "13.0.0", path = "../actors/miner" }
-fil_actor_multisig_state = { version = "13.0.0", path = "../actors/multisig" }
-fil_actor_power_state = { version = "13.0.0", path = "../actors/power" }
-fil_actor_reward_state = { version = "13.0.0", path = "../actors/reward" }
-fil_actor_system_state = { version = "13.0.0", path = "../actors/system" }
-fil_actor_verifreg_state = { version = "13.0.0", path = "../actors/verifreg" }
-fil_actors_shared = { version = "13.0.0", path = "../fil_actors_shared" }
+fil_actor_account_state.workspace = true
+fil_actor_cron_state.workspace = true
+fil_actor_datacap_state.workspace = true
+fil_actor_evm_state.workspace = true
+fil_actor_init_state.workspace = true
+fil_actor_market_state.workspace = true
+fil_actor_miner_state.workspace = true
+fil_actor_multisig_state.workspace = true
+fil_actor_power_state.workspace = true
+fil_actor_reward_state.workspace = true
+fil_actor_system_state.workspace = true
+fil_actor_verifreg_state.workspace = true
+fil_actors_shared.workspace = true
 
 anyhow.workspace = true
 cid.workspace = true

--- a/fil_actor_interface/src/builtin/miner/mod.rs
+++ b/fil_actor_interface/src/builtin/miner/mod.rs
@@ -315,6 +315,23 @@ impl State {
         }
     }
 
+    /// Returns the deadline and partition index for a sector number.
+    pub fn find_sector<BS: Blockstore>(
+        &self,
+        store: &BS,
+        sector_number: SectorNumber,
+        policy: &Policy,
+    ) -> anyhow::Result<(u64, u64)> {
+        match self {
+            State::V8(st) => st.find_sector(&from_policy_v13_to_v9(policy), store, sector_number),
+            State::V9(st) => st.find_sector(&from_policy_v13_to_v9(policy), store, sector_number),
+            State::V10(st) => st.find_sector(&from_policy_v13_to_v10(policy), store, sector_number),
+            State::V11(st) => st.find_sector(&from_policy_v13_to_v11(policy), store, sector_number),
+            State::V12(st) => st.find_sector(store, sector_number),
+            State::V13(st) => st.find_sector(store, sector_number),
+        }
+    }
+
     /// Gets fee debt of miner state
     pub fn fee_debt(&self) -> TokenAmount {
         match self {

--- a/fil_actor_interface/src/lib.rs
+++ b/fil_actor_interface/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 mod builtin;
-mod convert;
+pub mod convert;
 mod io;
 mod macros;
 mod r#mod;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

-  add `fn miner::State::get_sector` to unblock https://github.com/ChainSafe/forest/pull/4381
- bump crate minor versions
- refactor `Cargo.toml`s to not require updating >1 `Cargo.toml` files for future version bumps
- bump forest submodule


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->