### PR TITLE
fix: bug in verifreg::Claim conversion logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "13.1.0"
+version = "13.1.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ChainSafe/fil-actor-states"
 authors = [
@@ -82,18 +82,18 @@ toml = "0.8"
 uint = { version = "0.9.3", default-features = false }
 unsigned-varint = "0.8"
 
-fil_actor_account_state = { version = "13.1.0", path = "./actors/account" }
-fil_actor_cron_state = { version = "13.1.0", path = "./actors/cron" }
-fil_actor_datacap_state = { version = "13.1.0", path = "./actors/datacap" }
-fil_actor_evm_state = { version = "13.1.0", path = "./actors/evm" }
-fil_actor_init_state = { version = "13.1.0", path = "./actors/init" }
-fil_actor_market_state = { version = "13.1.0", path = "./actors/market" }
-fil_actor_miner_state = { version = "13.1.0", path = "./actors/miner" }
-fil_actor_multisig_state = { version = "13.1.0", path = "./actors/multisig" }
-fil_actor_power_state = { version = "13.1.0", path = "./actors/power" }
-fil_actor_reward_state = { version = "13.1.0", path = "./actors/reward" }
-fil_actor_system_state = { version = "13.1.0", path = "./actors/system" }
-fil_actor_verifreg_state = { version = "13.1.0", path = "./actors/verifreg" }
-fil_actors_shared = { version = "13.1.0", path = "./fil_actors_shared" }
+fil_actor_account_state = { version = "13.1.1", path = "./actors/account" }
+fil_actor_cron_state = { version = "13.1.1", path = "./actors/cron" }
+fil_actor_datacap_state = { version = "13.1.1", path = "./actors/datacap" }
+fil_actor_evm_state = { version = "13.1.1", path = "./actors/evm" }
+fil_actor_init_state = { version = "13.1.1", path = "./actors/init" }
+fil_actor_market_state = { version = "13.1.1", path = "./actors/market" }
+fil_actor_miner_state = { version = "13.1.1", path = "./actors/miner" }
+fil_actor_multisig_state = { version = "13.1.1", path = "./actors/multisig" }
+fil_actor_power_state = { version = "13.1.1", path = "./actors/power" }
+fil_actor_reward_state = { version = "13.1.1", path = "./actors/reward" }
+fil_actor_system_state = { version = "13.1.1", path = "./actors/system" }
+fil_actor_verifreg_state = { version = "13.1.1", path = "./actors/verifreg" }
+fil_actors_shared = { version = "13.1.1", path = "./fil_actors_shared" }
 
 fil_actors_test_utils = { path = "./fil_actors_test_utils" }

--- a/fil_actor_interface/src/builtin/verifreg/mod.rs
+++ b/fil_actor_interface/src/builtin/verifreg/mod.rs
@@ -302,8 +302,8 @@ macro_rules! from_claim {
         impl From<&$type> for Claim {
             fn from(claim: &$type) -> Self {
                 Self {
-                    provider: claim.client,
-                    client: claim.provider,
+                    provider: claim.provider,
+                    client: claim.client,
                     data: claim.data,
                     size: PaddedPieceSize(claim.size.0),
                     term_min: claim.term_min,


### PR DESCRIPTION
**Summary of changes**

Bug fix to unblock https://github.com/ChainSafe/forest/pull/4401

Changes introduced in this pull request:

- Fix a bug that `provider` and `client` fields are not properly assigned
- Bump patch versions
- Bump forest submodule


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->