### PR TITLE
chore(ci): speed up forest sync check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Install forest
         run: |
           cd forest
-          make install
+          make install-minimum-quick
         env:
           CC: "sccache clang"
           CXX: "sccache clang++"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

- speed up forest sync check by using `make install-minimum-quick` instead of `make install`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->