### PR TITLE
chore: bump rust toolchain

### DIFF
--- a/actors/paych/src/v10/types.rs
+++ b/actors/paych/src/v10/types.rs
@@ -13,7 +13,7 @@ use fvm_shared3::MethodNum;
 use super::Merge;
 
 /// Maximum number of lanes in a channel
-pub const MAX_LANE: u64 = std::i64::MAX as u64;
+pub const MAX_LANE: u64 = i64::MAX as u64;
 
 pub const SETTLE_DELAY: ChainEpoch = EPOCHS_IN_HOUR * 12;
 

--- a/actors/paych/src/v11/types.rs
+++ b/actors/paych/src/v11/types.rs
@@ -13,7 +13,7 @@ use fvm_shared3::MethodNum;
 use super::Merge;
 
 /// Maximum number of lanes in a channel
-pub const MAX_LANE: u64 = std::i64::MAX as u64;
+pub const MAX_LANE: u64 = i64::MAX as u64;
 
 pub const SETTLE_DELAY: ChainEpoch = EPOCHS_IN_HOUR * 12;
 

--- a/actors/paych/src/v12/types.rs
+++ b/actors/paych/src/v12/types.rs
@@ -13,7 +13,7 @@ use fvm_shared4::MethodNum;
 use super::Merge;
 
 /// Maximum number of lanes in a channel
-pub const MAX_LANE: u64 = std::i64::MAX as u64;
+pub const MAX_LANE: u64 = i64::MAX as u64;
 
 pub const SETTLE_DELAY: ChainEpoch = EPOCHS_IN_HOUR * 12;
 

--- a/actors/paych/src/v13/types.rs
+++ b/actors/paych/src/v13/types.rs
@@ -13,7 +13,7 @@ use fvm_shared4::MethodNum;
 use super::Merge;
 
 /// Maximum number of lanes in a channel
-pub const MAX_LANE: u64 = std::i64::MAX as u64;
+pub const MAX_LANE: u64 = i64::MAX as u64;
 
 pub const SETTLE_DELAY: ChainEpoch = EPOCHS_IN_HOUR * 12;
 

--- a/actors/paych/src/v8/types.rs
+++ b/actors/paych/src/v8/types.rs
@@ -13,7 +13,7 @@ use fvm_shared::MethodNum;
 use super::Merge;
 
 /// Maximum number of lanes in a channel
-pub const MAX_LANE: u64 = std::i64::MAX as u64;
+pub const MAX_LANE: u64 = i64::MAX as u64;
 
 pub const SETTLE_DELAY: ChainEpoch = EPOCHS_IN_HOUR * 12;
 

--- a/actors/paych/src/v9/types.rs
+++ b/actors/paych/src/v9/types.rs
@@ -13,7 +13,7 @@ use fvm_shared::MethodNum;
 use super::Merge;
 
 /// Maximum number of lanes in a channel
-pub const MAX_LANE: u64 = std::i64::MAX as u64;
+pub const MAX_LANE: u64 = i64::MAX as u64;
 
 pub const SETTLE_DELAY: ChainEpoch = EPOCHS_IN_HOUR * 12;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = []


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- bump rust toolchain to 1.79.0
- fix clippy warnings
- update forest submodule



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->