### PR TITLE
chore(deps): bump fvm_shared@4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "13.1.1"
+version = "14.0.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ChainSafe/fil-actor-states"
 authors = [
@@ -82,18 +82,18 @@ toml = "0.8"
 uint = { version = "0.9.3", default-features = false }
 unsigned-varint = "0.8"
 
-fil_actor_account_state = { version = "13.1.1", path = "./actors/account" }
-fil_actor_cron_state = { version = "13.1.1", path = "./actors/cron" }
-fil_actor_datacap_state = { version = "13.1.1", path = "./actors/datacap" }
-fil_actor_evm_state = { version = "13.1.1", path = "./actors/evm" }
-fil_actor_init_state = { version = "13.1.1", path = "./actors/init" }
-fil_actor_market_state = { version = "13.1.1", path = "./actors/market" }
-fil_actor_miner_state = { version = "13.1.1", path = "./actors/miner" }
-fil_actor_multisig_state = { version = "13.1.1", path = "./actors/multisig" }
-fil_actor_power_state = { version = "13.1.1", path = "./actors/power" }
-fil_actor_reward_state = { version = "13.1.1", path = "./actors/reward" }
-fil_actor_system_state = { version = "13.1.1", path = "./actors/system" }
-fil_actor_verifreg_state = { version = "13.1.1", path = "./actors/verifreg" }
-fil_actors_shared = { version = "13.1.1", path = "./fil_actors_shared" }
+fil_actor_account_state = { version = "14.0.0", path = "./actors/account" }
+fil_actor_cron_state = { version = "14.0.0", path = "./actors/cron" }
+fil_actor_datacap_state = { version = "14.0.0", path = "./actors/datacap" }
+fil_actor_evm_state = { version = "14.0.0", path = "./actors/evm" }
+fil_actor_init_state = { version = "14.0.0", path = "./actors/init" }
+fil_actor_market_state = { version = "14.0.0", path = "./actors/market" }
+fil_actor_miner_state = { version = "14.0.0", path = "./actors/miner" }
+fil_actor_multisig_state = { version = "14.0.0", path = "./actors/multisig" }
+fil_actor_power_state = { version = "14.0.0", path = "./actors/power" }
+fil_actor_reward_state = { version = "14.0.0", path = "./actors/reward" }
+fil_actor_system_state = { version = "14.0.0", path = "./actors/system" }
+fil_actor_verifreg_state = { version = "14.0.0", path = "./actors/verifreg" }
+fil_actors_shared = { version = "14.0.0", path = "./fil_actors_shared" }
 
 fil_actors_test_utils = { path = "./fil_actors_test_utils" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ base64 = "0.22"
 bitflags = "2.4.2"
 byteorder = "1.4.3"
 cid = { version = "0.10", default-features = false, features = ["std"] }
-frc42_macros = "4"
-frc46_token = "10.0.0"
+frc42_macros = "5"
+frc46_token = "11"
 fvm_ipld_amt = "0.6.1"
 fvm_ipld_bitfield = "0.6"
 fvm_ipld_blockstore = "0.2"
@@ -49,7 +49,7 @@ fvm_ipld_encoding = "0.4"
 fvm_ipld_hamt = "0.9.0"
 fvm_shared = { version = "~2.6", default-features = false }
 fvm_shared3 = { package = "fvm_shared", version = "~3.6", default-features = false }
-fvm_shared4 = { package = "fvm_shared", version = "~4.1.2", default-features = false }
+fvm_shared4 = { package = "fvm_shared", version = "~4.3", default-features = false }
 getrandom = { version = "0.2.12" }
 hex = "0.4.3"
 hex-literal = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ fvm_ipld_bitfield = "0.6"
 fvm_ipld_blockstore = "0.2"
 fvm_ipld_encoding = "0.4"
 fvm_ipld_hamt = "0.9.0"
-fvm_shared = { version = "~2.6", default-features = false }
-fvm_shared3 = { package = "fvm_shared", version = "~3.6", default-features = false }
+fvm_shared = { version = "~2.7", default-features = false }
+fvm_shared3 = { package = "fvm_shared", version = "~3.10", default-features = false }
 fvm_shared4 = { package = "fvm_shared", version = "~4.3", default-features = false }
 getrandom = { version = "0.2.12" }
 hex = "0.4.3"

--- a/fil_actors_shared/Cargo.toml
+++ b/fil_actors_shared/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 cid = { workspace = true }
-filecoin-proofs-api = { version = "16", default-features = false }
+filecoin-proofs-api = { version = "18", default-features = false }
 frc46_token = { workspace = true }
 fvm_ipld_amt = { workspace = true }
 fvm_ipld_bitfield = { workspace = true }

--- a/fil_actors_shared/src/lib.rs
+++ b/fil_actors_shared/src/lib.rs
@@ -10,6 +10,7 @@ pub mod v8;
 pub mod v9;
 
 // Re-exports
+pub extern crate frc46_token;
 pub extern crate fvm_ipld_amt;
 pub extern crate fvm_ipld_bitfield;
 pub extern crate fvm_ipld_blockstore;
@@ -17,6 +18,7 @@ pub extern crate fvm_ipld_encoding;
 pub extern crate fvm_ipld_hamt;
 pub extern crate fvm_shared as fvm_shared2;
 pub extern crate fvm_shared3;
+pub extern crate fvm_shared4;
 
 pub mod ext {
     use frc46_token::token::state::{actor_id_key, StateError, TokenState};

--- a/fil_actors_shared/src/lib.rs
+++ b/fil_actors_shared/src/lib.rs
@@ -10,6 +10,7 @@ pub mod v8;
 pub mod v9;
 
 // Re-exports
+pub extern crate filecoin_proofs_api;
 pub extern crate frc46_token;
 pub extern crate fvm_ipld_amt;
 pub extern crate fvm_ipld_bitfield;

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 crates=(
     "fil_actors_shared"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- bump `fvm_shared@4` version to `4.3`
- bump `fvm_shared@3` version to `3.10`
- bump `fvm_shared@2` version to `2.7`
- bump `frc46_token`, `frc42_macros` and `filecoin-proofs-api` versions
- re-export `fvm_shared4`, `frc46_token` and `filecoin_proofs_api`
- bump crate versions to `14.0.0`

`forest` integration tests are green in https://github.com/ChainSafe/forest/pull/4416

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->