### PR TITLE
fix: publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
       - v*
 env:
   RUSTC_WRAPPER: "sccache"
-  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   publish:
@@ -22,4 +21,4 @@ jobs:
       - name: Publish crates
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: ./scripts/publish.sh
+        run: ./scripts/publish.sh --token "$CRATES_IO_TOKEN"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.5
         timeout-minutes: 5
         continue-on-error: true
       - name: Publish crates

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Publish crates
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: ./scripts/publish.sh --token "$CRATES_IO_TOKEN"
+        run: ./scripts/publish.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,17 +137,3 @@ jobs:
           gem install toml-rb --no-document
           ruby scripts/find_duplicate_deps.rb && \
           ruby scripts/find_unused_deps.rb --ignore serde --ignore num --ignore num-bigint --ignore num-traits --ignore fvm_ipld_bitfield
-
-  cargo-publish-dry-run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.5
-        timeout-minutes: 5
-        continue-on-error: true
-      - name: Publish crates
-        env:
-          SCCACHE_GHA_ENABLED: "false"
-        run: ./scripts/publish.sh --dry-run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.5
         timeout-minutes: 5
         continue-on-error: true
       - uses: actions/setup-go@v5
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.5
         timeout-minutes: 5
         continue-on-error: true
       - name: Update submodule forest
@@ -97,7 +97,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.5
         timeout-minutes: 5
         continue-on-error: true
       - name: Apt Dependencies
@@ -144,7 +144,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.5
         timeout-minutes: 5
         continue-on-error: true
       - name: Publish crates

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,3 +137,17 @@ jobs:
           gem install toml-rb --no-document
           ruby scripts/find_duplicate_deps.rb && \
           ruby scripts/find_unused_deps.rb --ignore serde --ignore num --ignore num-bigint --ignore num-traits --ignore fvm_ipld_bitfield
+
+  cargo-publish-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
+        timeout-minutes: 5
+        continue-on-error: true
+      - name: Publish crates
+        env:
+          SCCACHE_GHA_ENABLED: "false"
+        run: ./scripts/publish.sh --dry-run

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -22,11 +22,6 @@ crates=(
 )
 
 for crate in "${crates[@]}"; do
-    crate_manifest=$(cargo metadata --no-deps --format-version 1 |
-    jq -r --arg crate "$crate" '.packages[] |
-    select(.name == $crate) |
-    .manifest_path')
-
     # Publish to crates.io
-    cargo publish --manifest-path "$crate_manifest" "$@" || echo "failed"
+    cargo publish --package "$crate" --token "$CRATES_IO_TOKEN" || echo "failed"
 done

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -9,7 +9,6 @@ crates=(
     "fil_actor_datacap_state"
     "fil_actor_eam_state"
     "fil_actor_ethaccount_state"
-    "fil_actor_evm_shared_state"
     "fil_actor_evm_state"
     "fil_actor_init_state"
     "fil_actor_market_state"
@@ -29,6 +28,6 @@ for crate in "${crates[@]}"; do
     .manifest_path')
 
     # Publish to crates.io
-    cargo publish --manifest-path "$crate_manifest" --token "$CRATES_IO_TOKEN"
+    cargo publish --manifest-path "$crate_manifest" "$@"
     cargo clean --manifest-path "$crate_manifest"
 done

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -28,6 +28,5 @@ for crate in "${crates[@]}"; do
     .manifest_path')
 
     # Publish to crates.io
-    cargo publish --manifest-path "$crate_manifest" "$@"
-    cargo clean --manifest-path "$crate_manifest"
+    cargo publish --manifest-path "$crate_manifest" "$@" || echo "failed"
 done

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -23,5 +23,5 @@ crates=(
 
 for crate in "${crates[@]}"; do
     # Publish to crates.io
-    cargo publish --package "$crate" --token "$CRATES_IO_TOKEN" || echo "failed"
+    cargo publish --package "$crate" --token "$CRATES_IO_TOKEN"
 done


### PR DESCRIPTION
**Summary of changes**

To resume publishing `v14.0.0` and unblock https://github.com/ChainSafe/forest/pull/4416
The publish failed for the non-existing `fil_actor_evm_shared_state` : https://github.com/ChainSafe/fil-actor-states/actions/runs/9583961899/job/26426418571#step:4:1196

Changes introduced in this pull request:
-  ~add `cargo-publish-dry-run` job~ This won't work when a PR contains version bump
- fix `publish.sh` by removing the non-existing `fil_actor_evm_shared_state`
- simplify `publish.sh` by removing the `cargo metadata` steps
- bump `mozilla-actions/sccache-action`
- disable sccache GHA backend for better publishing performance
- remove cargo clean step for better publishing performance


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->