### PR TITLE
[Feature] Backport outer map iteration for MapMap.

### DIFF
--- a/fil_actors_shared/src/v10/util/mapmap.rs
+++ b/fil_actors_shared/src/v10/util/mapmap.rs
@@ -108,6 +108,14 @@ where
         in_map.get(&inside_k.key())
     }
 
+    // Backport from v12+.
+    pub fn for_each_outer<F>(&self, f: F) -> Result<(), Error>
+    where
+        F: FnMut(&BytesKey, &Cid) -> anyhow::Result<()>,
+    {
+        self.outer.for_each(f)
+    }
+
     // Runs a function over all values for one outer key.
     pub fn for_each<F>(&mut self, outside_k: K1, f: F) -> Result<(), Error>
     where

--- a/fil_actors_shared/src/v11/util/mapmap.rs
+++ b/fil_actors_shared/src/v11/util/mapmap.rs
@@ -105,6 +105,14 @@ where
         in_map.get(&inside_k.key())
     }
 
+    // Backport from v12+.
+    pub fn for_each_outer<F>(&self, f: F) -> Result<(), Error>
+    where
+        F: FnMut(&BytesKey, &Cid) -> anyhow::Result<()>,
+    {
+        self.outer.for_each(f)
+    }
+
     // Runs a function over all values for one outer key.
     pub fn for_each<F>(&mut self, outside_k: K1, f: F) -> Result<(), Error>
     where

--- a/fil_actors_shared/src/v9/util/mapmap.rs
+++ b/fil_actors_shared/src/v9/util/mapmap.rs
@@ -108,6 +108,14 @@ where
         in_map.get(&inside_k.key())
     }
 
+    // Backport from v12+.
+    pub fn for_each_outer<F>(&self, f: F) -> Result<(), Error>
+    where
+        F: FnMut(&BytesKey, &Cid) -> anyhow::Result<()>,
+    {
+        self.outer.for_each(f)
+    }
+
     // Runs a function over all values for one outer key.
     pub fn for_each<F>(&mut self, outside_k: K1, f: F) -> Result<(), Error>
     where


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Introduces the ability to iterate outer keys of the double map.
