### PR TITLE
chore: upgrade rust toolchain to 1.80.0

### DIFF
--- a/fil_actors_shared/src/v13/vm_api/mod.rs
+++ b/fil_actors_shared/src/v13/vm_api/mod.rs
@@ -194,6 +194,7 @@ pub trait Primitives {
     /// - first header is of the same or lower epoch as the second
     /// - at least one of the headers appears in the current chain at or after epoch `earliest`
     /// - the headers provide evidence of a fault (see the spec for the different fault types).
+    ///
     /// The parameters are all serialized block headers. The third "extra" parameter is consulted only for
     /// the "parent grinding fault", in which case it must be the sibling of h1 (same parent tipset) and one of the
     /// blocks in the parent of h2 (i.e. h2's grandparent).

--- a/fil_actors_shared/src/v14/runtime/mod.rs
+++ b/fil_actors_shared/src/v14/runtime/mod.rs
@@ -213,6 +213,7 @@ pub trait Runtime: Primitives + RuntimePolicy {
     /// The circulating supply is the sum of:
     /// - rewards emitted by the reward actor,
     /// - funds vested from lock-ups in the genesis state,
+    ///
     /// less the sum of:
     /// - funds burnt,
     /// - pledge collateral locked in storage miner actors (recorded in the storage power actor)

--- a/fil_actors_shared/src/v14/vm_api/mod.rs
+++ b/fil_actors_shared/src/v14/vm_api/mod.rs
@@ -194,6 +194,7 @@ pub trait Primitives {
     /// - first header is of the same or lower epoch as the second
     /// - at least one of the headers appears in the current chain at or after epoch `earliest`
     /// - the headers provide evidence of a fault (see the spec for the different fault types).
+    ///
     /// The parameters are all serialized block headers. The third "extra" parameter is consulted only for
     /// the "parent grinding fault", in which case it must be the sibling of h1 (same parent tipset) and one of the
     /// blocks in the parent of h2 (i.e. h2's grandparent).

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.80.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = []


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- upgrade rust toolchain to 1.80.0
- upgrade forest submodule
- fix clippy warnings



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->