### PR TITLE
feat: wrap the 'recorded_deadline_info' miner function

### DIFF
--- a/fil_actor_interface/src/builtin/miner/mod.rs
+++ b/fil_actor_interface/src/builtin/miner/mod.rs
@@ -330,6 +330,36 @@ impl State {
                 .into(),
         }
     }
+
+    /// Returns deadline calculations for the state recorded proving period and deadline.
+    /// This is out of date if the a miner does not have an active miner cron
+    pub fn recorded_deadline_info(
+        &self,
+        policy: &Policy,
+        current_epoch: ChainEpoch,
+    ) -> DeadlineInfo {
+        match self {
+            State::V8(st) => st
+                .recorded_deadline_info(&from_policy_v13_to_v9(policy), current_epoch)
+                .into(),
+            State::V9(st) => st
+                .recorded_deadline_info(&from_policy_v13_to_v9(policy), current_epoch)
+                .into(),
+            State::V10(st) => st
+                .recorded_deadline_info(&from_policy_v13_to_v10(policy), current_epoch)
+                .into(),
+            State::V11(st) => st
+                .recorded_deadline_info(&from_policy_v13_to_v11(policy), current_epoch)
+                .into(),
+            State::V12(st) => st
+                .recorded_deadline_info(&from_policy_v13_to_v12(policy), current_epoch)
+                .into(),
+            State::V13(st) => st.recorded_deadline_info(policy, current_epoch).into(),
+            State::V14(st) => st
+                .recorded_deadline_info(&from_policy_v13_to_v14(policy), current_epoch)
+                .into(),
+        }
+    }
 }
 
 /// Static information about miner


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- `recorded_deadline_info` has small differences from `deadline_info`. We probably need both functions.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Required by https://github.com/ChainSafe/forest/issues/4630


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->