### PR TITLE
chore: prune deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ fvm_ipld_hamt = "0.9.0"
 fvm_shared = { version = "~2.7", default-features = false }
 fvm_shared3 = { package = "fvm_shared", version = "~3.10", default-features = false }
 fvm_shared4 = { package = "fvm_shared", version = "~4.3", default-features = false }
-getrandom = { version = "0.2.12" }
 hex = "0.4.3"
 hex-literal = "0.4"
 indexmap = { version = "2", features = ["serde"] }

--- a/fil_actor_interface/Cargo.toml
+++ b/fil_actor_interface/Cargo.toml
@@ -32,16 +32,6 @@ fvm_shared = { workspace = true }
 fvm_shared3 = { workspace = true }
 fvm_shared4 = { workspace = true }
 integer-encoding.workspace = true
-lazy_static.workspace = true
 multihash = { workspace = true, features = ["identity"] }
 num.workspace = true
-once_cell = "1.18.0"
 serde.workspace = true
-serde_json.workspace = true
-
-[build-dependencies]
-anyhow.workspace = true
-cid.workspace = true
-regex.workspace = true
-serde.workspace = true
-serde_json.workspace = true

--- a/fil_actors_shared/Cargo.toml
+++ b/fil_actors_shared/Cargo.toml
@@ -25,8 +25,6 @@ integer-encoding = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 multihash = { workspace = true }
-num = { workspace = true }
-num-bigint = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 paste = { workspace = true }
@@ -34,7 +32,6 @@ quickcheck = { workspace = true, optional = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_repr = { workspace = true }
-sha2 = { workspace = true }
 thiserror = { workspace = true }
 unsigned-varint = { workspace = true }
 
@@ -51,4 +48,3 @@ fil_actors_test_utils.workspace = true
 hex.workspace = true
 quickcheck.workspace = true
 quickcheck_macros.workspace = true
-toml.workspace = true


### PR DESCRIPTION
**Summary of changes**

Some dependencies are no longer needed but weren't cleaned in the past. Sadly, the tooling I used to assert this is lacking;
  - `cargo udeps` had lots of false negatives
  - our ruby script had lots of false positives

With some back and forth with the compiler, I managed to prune the dependencies a bit. It compiles fine on Forest `shashank/v15-builtin-actors`.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->