### PR TITLE
chore: relax FVM version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ fvm_ipld_bitfield = "0.6"
 fvm_ipld_blockstore = "0.2"
 fvm_ipld_encoding = "0.4"
 fvm_ipld_hamt = "0.9.0"
-fvm_shared = { version = "~2.7", default-features = false }
-fvm_shared3 = { package = "fvm_shared", version = "~3.10", default-features = false }
-fvm_shared4 = { package = "fvm_shared", version = "~4.3", default-features = false }
+fvm_shared = { version = "~2", default-features = false }
+fvm_shared3 = { package = "fvm_shared", version = "~3", default-features = false }
+fvm_shared4 = { package = "fvm_shared", version = "~4", default-features = false }
 hex = "0.4.3"
 hex-literal = "0.4"
 indexmap = { version = "2", features = ["serde"] }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- the current requirement is a bit strict for a library. If I want to update the FVM to, e.g., `4.3.3` in Forest, I'd need to do it also here, go through release process etc. This PR relaxes the requirement so that the binary _chooses_ the right minor version.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Part of https://github.com/ChainSafe/forest/issues/4806


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->