### PR TITLE
chore(deps): upgrade fvm_shared and cid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "17.0.3"
+version = "18.0.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ChainSafe/fil-actor-states"
 authors = [
@@ -37,8 +37,8 @@ keywords = ["filecoin", "web3", "wasm"]
 ahash = "0.8"
 anyhow = "1.0"
 base64 = "0.22"
-bitflags = "2.4.2"
-byteorder = "1.4.3"
+bitflags = "2"
+byteorder = "1"
 cid = { version = "0.11", default-features = false, features = ["std"] }
 frc42_dispatch = "8"
 frc42_macros = "6"
@@ -51,49 +51,49 @@ fvm_ipld_hamt = "0.10"
 fvm_shared = { version = "~2", default-features = false }
 fvm_shared3 = { package = "fvm_shared", version = "~3", default-features = false }
 fvm_shared4 = { package = "fvm_shared", version = "~4", default-features = false }
-hex = "0.4.3"
+hex = "0.4"
 hex-literal = "0.4"
 indexmap = { version = "2", features = ["serde"] }
 integer-encoding = { version = "4", default-features = false }
 ipld-core = { version = "0.4", features = ["serde"] }
 itertools = "0.13"
-lazy_static = "1.4"
+lazy_static = "1"
 log = "0.4"
 multihash-codetable = { version = "0.1", features = ["sha2"] }
-num = "0.4.0"
-num-bigint = { version = "0.4.3", features = ["serde"] }
+num = "0.4"
+num-bigint = { version = "0.4", features = ["serde"] }
 num-derive = "0.4"
 num-traits = "0.2"
 parking_lot = "0.12"
-paste = "1.0.9"
-pretty_assertions = "1.3.0"
+paste = "1"
+pretty_assertions = "1"
 quickcheck = "1"
 quickcheck_macros = "1"
 rand = "0.8"
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-serde_repr = "0.1.18"
-serde_tuple = "1.0"
+serde_repr = "0.1"
+serde_tuple = "1"
 serde_yaml = "0.9"
-sha2 = "0.10.8"
+sha2 = "0.10"
 thiserror = "2"
 toml = "0.8"
-uint = { version = "0.9.3", default-features = false }
+uint = { version = "0.9", default-features = false }
 unsigned-varint = "0.8"
 
-fil_actor_account_state = { version = "17.0.3", path = "./actors/account" }
-fil_actor_cron_state = { version = "17.0.3", path = "./actors/cron" }
-fil_actor_datacap_state = { version = "17.0.3", path = "./actors/datacap" }
-fil_actor_evm_state = { version = "17.0.3", path = "./actors/evm" }
-fil_actor_init_state = { version = "17.0.3", path = "./actors/init" }
-fil_actor_market_state = { version = "17.0.3", path = "./actors/market" }
-fil_actor_miner_state = { version = "17.0.3", path = "./actors/miner" }
-fil_actor_multisig_state = { version = "17.0.3", path = "./actors/multisig" }
-fil_actor_power_state = { version = "17.0.3", path = "./actors/power" }
-fil_actor_reward_state = { version = "17.0.3", path = "./actors/reward" }
-fil_actor_system_state = { version = "17.0.3", path = "./actors/system" }
-fil_actor_verifreg_state = { version = "17.0.3", path = "./actors/verifreg" }
-fil_actors_shared = { version = "17.0.3", path = "./fil_actors_shared" }
+fil_actor_account_state = { version = "18.0.0", path = "./actors/account" }
+fil_actor_cron_state = { version = "18.0.0", path = "./actors/cron" }
+fil_actor_datacap_state = { version = "18.0.0", path = "./actors/datacap" }
+fil_actor_evm_state = { version = "18.0.0", path = "./actors/evm" }
+fil_actor_init_state = { version = "18.0.0", path = "./actors/init" }
+fil_actor_market_state = { version = "18.0.0", path = "./actors/market" }
+fil_actor_miner_state = { version = "18.0.0", path = "./actors/miner" }
+fil_actor_multisig_state = { version = "18.0.0", path = "./actors/multisig" }
+fil_actor_power_state = { version = "18.0.0", path = "./actors/power" }
+fil_actor_reward_state = { version = "18.0.0", path = "./actors/reward" }
+fil_actor_system_state = { version = "18.0.0", path = "./actors/system" }
+fil_actor_verifreg_state = { version = "18.0.0", path = "./actors/verifreg" }
+fil_actors_shared = { version = "18.0.0", path = "./fil_actors_shared" }
 
 fil_actors_test_utils = { path = "./fil_actors_test_utils" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,15 +39,15 @@ anyhow = "1.0"
 base64 = "0.22"
 bitflags = "2.4.2"
 byteorder = "1.4.3"
-cid = { version = "0.10", default-features = false, features = ["std"] }
-frc42_dispatch = "7.0.0"
-frc42_macros = "5"
-frc46_token = "11"
-fvm_ipld_amt = "0.6.1"
-fvm_ipld_bitfield = "0.6"
-fvm_ipld_blockstore = "0.2"
-fvm_ipld_encoding = "0.4"
-fvm_ipld_hamt = "0.9.0"
+cid = { version = "0.11", default-features = false, features = ["std"] }
+frc42_dispatch = "8"
+frc42_macros = "6"
+frc46_token = "12"
+fvm_ipld_amt = "0.7"
+fvm_ipld_bitfield = "0.7"
+fvm_ipld_blockstore = "0.3"
+fvm_ipld_encoding = "0.5"
+fvm_ipld_hamt = "0.10"
 fvm_shared = { version = "~2", default-features = false }
 fvm_shared3 = { package = "fvm_shared", version = "~3", default-features = false }
 fvm_shared4 = { package = "fvm_shared", version = "~4", default-features = false }
@@ -55,11 +55,11 @@ hex = "0.4.3"
 hex-literal = "0.4"
 indexmap = { version = "2", features = ["serde"] }
 integer-encoding = { version = "4", default-features = false }
+ipld-core = { version = "0.4", features = ["serde"] }
 itertools = "0.13"
 lazy_static = "1.4"
-libipld-core = "0.16"
 log = "0.4"
-multihash = "0.18"
+multihash-codetable = { version = "0.1", features = ["sha2"] }
 num = "0.4.0"
 num-bigint = { version = "0.4.3", features = ["serde"] }
 num-derive = "0.4"
@@ -77,7 +77,7 @@ serde_repr = "0.1.18"
 serde_tuple = "1.0"
 serde_yaml = "0.9"
 sha2 = "0.10.8"
-thiserror = "1.0"
+thiserror = "2"
 toml = "0.8"
 uint = { version = "0.9.3", default-features = false }
 unsigned-varint = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ serde_yaml = "0.9"
 sha2 = "0.10"
 thiserror = "2"
 toml = "0.8"
-uint = { version = "0.9", default-features = false }
+uint = { version = "0.10", default-features = false }
 unsigned-varint = "0.8"
 
 fil_actor_account_state = { version = "18.0.0", path = "./actors/account" }

--- a/actors/evm/src/evm_shared/v10/address.rs
+++ b/actors/evm/src/evm_shared/v10/address.rs
@@ -16,8 +16,7 @@ pub struct EthAddress(#[serde(with = "strict_bytes")] pub [u8; 20]);
 /// Per the EVM spec, this simply discards the high bytes.
 impl From<U256> for EthAddress {
     fn from(v: U256) -> Self {
-        let mut bytes = [0u8; 32];
-        v.to_big_endian(&mut bytes);
+        let bytes = v.to_big_endian();
         Self(bytes[12..].try_into().unwrap())
     }
 }
@@ -128,7 +127,7 @@ mod tests {
             #[test]
             fn $name() {
                 let evm_bytes = $input.concat();
-                let evm_addr = EthAddress::from(U256::from(evm_bytes.as_slice()));
+                let evm_addr = EthAddress::from(U256::from_big_endian(evm_bytes.as_slice()));
                 assert_eq!(
                     evm_addr.as_id(),
                     $expectation

--- a/actors/evm/src/evm_shared/v10/uints.rs
+++ b/actors/evm/src/evm_shared/v10/uints.rs
@@ -150,9 +150,7 @@ impl U256 {
     }
 
     pub fn to_bytes(&self) -> [u8; 32] {
-        let mut buf = [0u8; 32];
-        self.to_big_endian(&mut buf);
-        buf
+        self.to_big_endian()
     }
 
     /// Returns the low 64 bits, saturating the value to u64 max if it is larger
@@ -175,7 +173,7 @@ impl U512 {
 impl From<&TokenAmount> for U256 {
     fn from(amount: &TokenAmount) -> U256 {
         let (_, bytes) = amount.atto().to_bytes_be();
-        U256::from(bytes.as_slice())
+        U256::from_big_endian(bytes.as_slice())
     }
 }
 
@@ -188,8 +186,7 @@ impl From<U256> for U512 {
 
 impl From<&U256> for TokenAmount {
     fn from(ui: &U256) -> TokenAmount {
-        let mut bits = [0u8; 32];
-        ui.to_big_endian(&mut bits);
+        let bits = ui.to_big_endian();
         TokenAmount::from_atto(BigInt::from_bytes_be(
             fvm_shared3::bigint::Sign::Plus,
             &bits,
@@ -202,8 +199,7 @@ impl Serialize for U256 {
     where
         S: serde::Serializer,
     {
-        let mut bytes = [0u8; 32];
-        self.to_big_endian(&mut bytes);
+        let bytes = self.to_big_endian();
         serializer.serialize_bytes(zeroless_view(&bytes))
     }
 }
@@ -316,7 +312,7 @@ mod tests {
         let one = U256::ONE.i256_neg();
         assert!(one.i256_is_negative());
 
-        let neg_one = U256::from(&[0xff; 32]);
+        let neg_one = U256::from_big_endian(&[0xff; 32]);
         let pos_one = neg_one.i256_neg();
         assert_eq!(pos_one, U256::ONE);
     }

--- a/actors/evm/src/evm_shared/v11/address.rs
+++ b/actors/evm/src/evm_shared/v11/address.rs
@@ -16,8 +16,7 @@ pub struct EthAddress(#[serde(with = "strict_bytes")] pub [u8; 20]);
 /// Per the EVM spec, this simply discards the high bytes.
 impl From<U256> for EthAddress {
     fn from(v: U256) -> Self {
-        let mut bytes = [0u8; 32];
-        v.to_big_endian(&mut bytes);
+        let bytes = v.to_big_endian();
         Self(bytes[12..].try_into().unwrap())
     }
 }
@@ -128,7 +127,7 @@ mod tests {
             #[test]
             fn $name() {
                 let evm_bytes = $input.concat();
-                let evm_addr = EthAddress::from(U256::from(evm_bytes.as_slice()));
+                let evm_addr = EthAddress::from(U256::from_big_endian(evm_bytes.as_slice()));
                 assert_eq!(
                     evm_addr.as_id(),
                     $expectation

--- a/actors/evm/src/evm_shared/v11/uints.rs
+++ b/actors/evm/src/evm_shared/v11/uints.rs
@@ -151,9 +151,7 @@ impl U256 {
     }
 
     pub fn to_bytes(&self) -> [u8; 32] {
-        let mut buf = [0u8; 32];
-        self.to_big_endian(&mut buf);
-        buf
+        self.to_big_endian()
     }
 
     /// Returns the low 64 bits, saturating the value to u64 max if it is larger
@@ -176,7 +174,7 @@ impl U512 {
 impl From<&TokenAmount> for U256 {
     fn from(amount: &TokenAmount) -> U256 {
         let (_, bytes) = amount.atto().to_bytes_be();
-        U256::from(bytes.as_slice())
+        U256::from_big_endian(bytes.as_slice())
     }
 }
 
@@ -189,8 +187,7 @@ impl From<U256> for U512 {
 
 impl From<&U256> for TokenAmount {
     fn from(ui: &U256) -> TokenAmount {
-        let mut bits = [0u8; 32];
-        ui.to_big_endian(&mut bits);
+        let bits = ui.to_big_endian();
         TokenAmount::from_atto(BigInt::from_bytes_be(
             fvm_shared3::bigint::Sign::Plus,
             &bits,
@@ -203,8 +200,7 @@ impl Serialize for U256 {
     where
         S: serde::Serializer,
     {
-        let mut bytes = [0u8; 32];
-        self.to_big_endian(&mut bytes);
+        let bytes = self.to_big_endian();
         serializer.serialize_bytes(zeroless_view(&bytes))
     }
 }
@@ -317,7 +313,7 @@ mod tests {
         let one = U256::ONE.i256_neg();
         assert!(one.i256_is_negative());
 
-        let neg_one = U256::from(&[0xff; 32]);
+        let neg_one = U256::from_big_endian(&[0xff; 32]);
         let pos_one = neg_one.i256_neg();
         assert_eq!(pos_one, U256::ONE);
     }

--- a/actors/evm/src/evm_shared/v12/address.rs
+++ b/actors/evm/src/evm_shared/v12/address.rs
@@ -16,8 +16,7 @@ pub struct EthAddress(#[serde(with = "strict_bytes")] pub [u8; 20]);
 /// Per the EVM spec, this simply discards the high bytes.
 impl From<U256> for EthAddress {
     fn from(v: U256) -> Self {
-        let mut bytes = [0u8; 32];
-        v.to_big_endian(&mut bytes);
+        let bytes = v.to_big_endian();
         Self(bytes[12..].try_into().unwrap())
     }
 }
@@ -128,7 +127,7 @@ mod tests {
             #[test]
             fn $name() {
                 let evm_bytes = $input.concat();
-                let evm_addr = EthAddress::from(U256::from(evm_bytes.as_slice()));
+                let evm_addr = EthAddress::from(U256::from_big_endian(evm_bytes.as_slice()));
                 assert_eq!(
                     evm_addr.as_id(),
                     $expectation

--- a/actors/evm/src/evm_shared/v12/uints.rs
+++ b/actors/evm/src/evm_shared/v12/uints.rs
@@ -145,9 +145,7 @@ impl U256 {
     }
 
     pub fn to_bytes(&self) -> [u8; 32] {
-        let mut buf = [0u8; 32];
-        self.to_big_endian(&mut buf);
-        buf
+        self.to_big_endian()
     }
 
     /// Returns the low 64 bits, saturating the value to u64 max if it is larger
@@ -170,7 +168,7 @@ impl U512 {
 impl From<&TokenAmount> for U256 {
     fn from(amount: &TokenAmount) -> U256 {
         let (_, bytes) = amount.atto().to_bytes_be();
-        U256::from(bytes.as_slice())
+        U256::from_big_endian(bytes.as_slice())
     }
 }
 
@@ -183,8 +181,7 @@ impl From<U256> for U512 {
 
 impl From<&U256> for TokenAmount {
     fn from(ui: &U256) -> TokenAmount {
-        let mut bits = [0u8; 32];
-        ui.to_big_endian(&mut bits);
+        let bits = ui.to_big_endian();
         TokenAmount::from_atto(BigInt::from_bytes_be(
             fvm_shared4::bigint::Sign::Plus,
             &bits,
@@ -197,8 +194,7 @@ impl Serialize for U256 {
     where
         S: serde::Serializer,
     {
-        let mut bytes = [0u8; 32];
-        self.to_big_endian(&mut bytes);
+        let bytes = self.to_big_endian();
         serializer.serialize_bytes(zeroless_view(&bytes))
     }
 }
@@ -315,7 +311,7 @@ mod tests {
         let one = U256::ONE.i256_neg();
         assert!(one.i256_is_negative());
 
-        let neg_one = U256::from(&[0xff; 32]);
+        let neg_one = U256::from_big_endian(&[0xff; 32]);
         let pos_one = neg_one.i256_neg();
         assert_eq!(pos_one, U256::ONE);
     }

--- a/actors/evm/src/evm_shared/v13/address.rs
+++ b/actors/evm/src/evm_shared/v13/address.rs
@@ -13,8 +13,7 @@ pub struct EthAddress(#[serde(with = "strict_bytes")] pub [u8; 20]);
 /// Per the EVM spec, this simply discards the high bytes.
 impl From<U256> for EthAddress {
     fn from(v: U256) -> Self {
-        let mut bytes = [0u8; 32];
-        v.to_big_endian(&mut bytes);
+        let bytes = v.to_big_endian();
         Self(bytes[12..].try_into().unwrap())
     }
 }
@@ -125,7 +124,7 @@ mod tests {
             #[test]
             fn $name() {
                 let evm_bytes = $input.concat();
-                let evm_addr = EthAddress::from(U256::from(evm_bytes.as_slice()));
+                let evm_addr = EthAddress::from(U256::from_big_endian(evm_bytes.as_slice()));
                 assert_eq!(
                     evm_addr.as_id(),
                     $expectation

--- a/actors/evm/src/evm_shared/v13/uints.rs
+++ b/actors/evm/src/evm_shared/v13/uints.rs
@@ -142,9 +142,7 @@ impl U256 {
     }
 
     pub fn to_bytes(&self) -> [u8; 32] {
-        let mut buf = [0u8; 32];
-        self.to_big_endian(&mut buf);
-        buf
+        self.to_big_endian()
     }
 
     /// Returns the low 64 bits, saturating the value to u64 max if it is larger
@@ -167,7 +165,7 @@ impl U512 {
 impl From<&TokenAmount> for U256 {
     fn from(amount: &TokenAmount) -> U256 {
         let (_, bytes) = amount.atto().to_bytes_be();
-        U256::from(bytes.as_slice())
+        U256::from_big_endian(bytes.as_slice())
     }
 }
 
@@ -180,8 +178,7 @@ impl From<U256> for U512 {
 
 impl From<&U256> for TokenAmount {
     fn from(ui: &U256) -> TokenAmount {
-        let mut bits = [0u8; 32];
-        ui.to_big_endian(&mut bits);
+        let bits = ui.to_big_endian();
         TokenAmount::from_atto(BigInt::from_bytes_be(
             fvm_shared4::bigint::Sign::Plus,
             &bits,
@@ -194,8 +191,7 @@ impl Serialize for U256 {
     where
         S: serde::Serializer,
     {
-        let mut bytes = [0u8; 32];
-        self.to_big_endian(&mut bytes);
+        let bytes = self.to_big_endian();
         serializer.serialize_bytes(zeroless_view(&bytes))
     }
 }
@@ -312,7 +308,7 @@ mod tests {
         let one = U256::ONE.i256_neg();
         assert!(one.i256_is_negative());
 
-        let neg_one = U256::from(&[0xff; 32]);
+        let neg_one = U256::from_big_endian(&[0xff; 32]);
         let pos_one = neg_one.i256_neg();
         assert_eq!(pos_one, U256::ONE);
     }

--- a/actors/evm/src/evm_shared/v14/address.rs
+++ b/actors/evm/src/evm_shared/v14/address.rs
@@ -13,8 +13,7 @@ pub struct EthAddress(#[serde(with = "strict_bytes")] pub [u8; 20]);
 /// Per the EVM spec, this simply discards the high bytes.
 impl From<U256> for EthAddress {
     fn from(v: U256) -> Self {
-        let mut bytes = [0u8; 32];
-        v.to_big_endian(&mut bytes);
+        let bytes = v.to_big_endian();
         Self(bytes[12..].try_into().unwrap())
     }
 }
@@ -125,7 +124,7 @@ mod tests {
             #[test]
             fn $name() {
                 let evm_bytes = $input.concat();
-                let evm_addr = EthAddress::from(U256::from(evm_bytes.as_slice()));
+                let evm_addr = EthAddress::from(U256::from_big_endian(evm_bytes.as_slice()));
                 assert_eq!(
                     evm_addr.as_id(),
                     $expectation

--- a/actors/evm/src/evm_shared/v14/uints.rs
+++ b/actors/evm/src/evm_shared/v14/uints.rs
@@ -142,9 +142,7 @@ impl U256 {
     }
 
     pub fn to_bytes(&self) -> [u8; 32] {
-        let mut buf = [0u8; 32];
-        self.to_big_endian(&mut buf);
-        buf
+        self.to_big_endian()
     }
 
     /// Returns the low 64 bits, saturating the value to u64 max if it is larger
@@ -167,7 +165,7 @@ impl U512 {
 impl From<&TokenAmount> for U256 {
     fn from(amount: &TokenAmount) -> U256 {
         let (_, bytes) = amount.atto().to_bytes_be();
-        U256::from(bytes.as_slice())
+        U256::from_big_endian(bytes.as_slice())
     }
 }
 
@@ -180,8 +178,7 @@ impl From<U256> for U512 {
 
 impl From<&U256> for TokenAmount {
     fn from(ui: &U256) -> TokenAmount {
-        let mut bits = [0u8; 32];
-        ui.to_big_endian(&mut bits);
+        let bits = ui.to_big_endian();
         TokenAmount::from_atto(BigInt::from_bytes_be(
             fvm_shared4::bigint::Sign::Plus,
             &bits,
@@ -194,8 +191,7 @@ impl Serialize for U256 {
     where
         S: serde::Serializer,
     {
-        let mut bytes = [0u8; 32];
-        self.to_big_endian(&mut bytes);
+        let bytes = self.to_big_endian();
         serializer.serialize_bytes(zeroless_view(&bytes))
     }
 }
@@ -312,7 +308,7 @@ mod tests {
         let one = U256::ONE.i256_neg();
         assert!(one.i256_is_negative());
 
-        let neg_one = U256::from(&[0xff; 32]);
+        let neg_one = U256::from_big_endian(&[0xff; 32]);
         let pos_one = neg_one.i256_neg();
         assert_eq!(pos_one, U256::ONE);
     }

--- a/actors/evm/src/evm_shared/v15/address.rs
+++ b/actors/evm/src/evm_shared/v15/address.rs
@@ -13,8 +13,7 @@ pub struct EthAddress(#[serde(with = "strict_bytes")] pub [u8; 20]);
 /// Per the EVM spec, this simply discards the high bytes.
 impl From<U256> for EthAddress {
     fn from(v: U256) -> Self {
-        let mut bytes = [0u8; 32];
-        v.to_big_endian(&mut bytes);
+        let bytes = v.to_big_endian();
         Self(bytes[12..].try_into().unwrap())
     }
 }
@@ -125,7 +124,7 @@ mod tests {
             #[test]
             fn $name() {
                 let evm_bytes = $input.concat();
-                let evm_addr = EthAddress::from(U256::from(evm_bytes.as_slice()));
+                let evm_addr = EthAddress::from(U256::from_big_endian(evm_bytes.as_slice()));
                 assert_eq!(
                     evm_addr.as_id(),
                     $expectation

--- a/actors/evm/src/evm_shared/v15/uints.rs
+++ b/actors/evm/src/evm_shared/v15/uints.rs
@@ -142,9 +142,7 @@ impl U256 {
     }
 
     pub fn to_bytes(&self) -> [u8; 32] {
-        let mut buf = [0u8; 32];
-        self.to_big_endian(&mut buf);
-        buf
+        self.to_big_endian()
     }
 
     /// Returns the low 64 bits, saturating the value to u64 max if it is larger
@@ -167,7 +165,7 @@ impl U512 {
 impl From<&TokenAmount> for U256 {
     fn from(amount: &TokenAmount) -> U256 {
         let (_, bytes) = amount.atto().to_bytes_be();
-        U256::from(bytes.as_slice())
+        U256::from_big_endian(bytes.as_slice())
     }
 }
 
@@ -180,8 +178,7 @@ impl From<U256> for U512 {
 
 impl From<&U256> for TokenAmount {
     fn from(ui: &U256) -> TokenAmount {
-        let mut bits = [0u8; 32];
-        ui.to_big_endian(&mut bits);
+        let bits = ui.to_big_endian();
         TokenAmount::from_atto(BigInt::from_bytes_be(
             fvm_shared4::bigint::Sign::Plus,
             &bits,
@@ -194,8 +191,7 @@ impl Serialize for U256 {
     where
         S: serde::Serializer,
     {
-        let mut bytes = [0u8; 32];
-        self.to_big_endian(&mut bytes);
+        let bytes = self.to_big_endian();
         serializer.serialize_bytes(zeroless_view(&bytes))
     }
 }
@@ -312,7 +308,7 @@ mod tests {
         let one = U256::ONE.i256_neg();
         assert!(one.i256_is_negative());
 
-        let neg_one = U256::from(&[0xff; 32]);
+        let neg_one = U256::from_big_endian(&[0xff; 32]);
         let pos_one = neg_one.i256_neg();
         assert_eq!(pos_one, U256::ONE);
     }

--- a/actors/evm/src/v10/state.rs
+++ b/actors/evm/src/v10/state.rs
@@ -85,7 +85,7 @@ impl From<BytecodeHash> for Vec<u8> {
 impl From<BytecodeHash> for U256 {
     fn from(bytecode: BytecodeHash) -> Self {
         let bytes: [u8; 32] = bytecode.into();
-        Self::from(bytes)
+        Self::from_big_endian(&bytes)
     }
 }
 

--- a/actors/evm/src/v11/state.rs
+++ b/actors/evm/src/v11/state.rs
@@ -85,7 +85,7 @@ impl From<BytecodeHash> for Vec<u8> {
 impl From<BytecodeHash> for U256 {
     fn from(bytecode: BytecodeHash) -> Self {
         let bytes: [u8; 32] = bytecode.into();
-        Self::from(bytes)
+        Self::from_big_endian(&bytes)
     }
 }
 

--- a/actors/evm/src/v12/state.rs
+++ b/actors/evm/src/v12/state.rs
@@ -84,7 +84,7 @@ impl From<BytecodeHash> for Vec<u8> {
 impl From<BytecodeHash> for U256 {
     fn from(bytecode: BytecodeHash) -> Self {
         let bytes: [u8; 32] = bytecode.into();
-        Self::from(bytes)
+        Self::from_big_endian(&bytes)
     }
 }
 

--- a/actors/evm/src/v13/state.rs
+++ b/actors/evm/src/v13/state.rs
@@ -81,7 +81,7 @@ impl From<BytecodeHash> for Vec<u8> {
 impl From<BytecodeHash> for U256 {
     fn from(bytecode: BytecodeHash) -> Self {
         let bytes: [u8; 32] = bytecode.into();
-        Self::from(bytes)
+        Self::from_big_endian(&bytes)
     }
 }
 

--- a/actors/evm/src/v14/state.rs
+++ b/actors/evm/src/v14/state.rs
@@ -81,7 +81,7 @@ impl From<BytecodeHash> for Vec<u8> {
 impl From<BytecodeHash> for U256 {
     fn from(bytecode: BytecodeHash) -> Self {
         let bytes: [u8; 32] = bytecode.into();
-        Self::from(bytes)
+        Self::from_big_endian(&bytes)
     }
 }
 

--- a/actors/evm/src/v15/state.rs
+++ b/actors/evm/src/v15/state.rs
@@ -81,7 +81,7 @@ impl From<BytecodeHash> for Vec<u8> {
 impl From<BytecodeHash> for U256 {
     fn from(bytecode: BytecodeHash) -> Self {
         let bytes: [u8; 32] = bytecode.into();
-        Self::from(bytes)
+        Self::from_big_endian(&bytes)
     }
 }
 

--- a/actors/market/Cargo.toml
+++ b/actors/market/Cargo.toml
@@ -25,8 +25,9 @@ fvm_ipld_hamt = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_shared3 = { workspace = true }
 fvm_shared4 = { workspace = true }
+ipld-core = { workspace = true }
 lazy_static = { workspace = true }
-libipld-core = { workspace = true }
+multihash-codetable = { workspace = true }
 num-bigint = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }

--- a/actors/market/src/v10/deal.rs
+++ b/actors/market/src/v10/deal.rs
@@ -11,7 +11,7 @@ use fvm_shared3::commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED};
 use fvm_shared3::crypto::signature::Signature;
 use fvm_shared3::econ::TokenAmount;
 use fvm_shared3::piece::PaddedPieceSize;
-use libipld_core::ipld::Ipld;
+use ipld_core::ipld::Ipld;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::{TryFrom, TryInto};
 

--- a/actors/market/src/v11/deal.rs
+++ b/actors/market/src/v11/deal.rs
@@ -11,7 +11,7 @@ use fvm_shared3::commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED};
 use fvm_shared3::crypto::signature::Signature;
 use fvm_shared3::econ::TokenAmount;
 use fvm_shared3::piece::PaddedPieceSize;
-use libipld_core::ipld::Ipld;
+use ipld_core::ipld::Ipld;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::{TryFrom, TryInto};
 

--- a/actors/market/src/v12/deal.rs
+++ b/actors/market/src/v12/deal.rs
@@ -11,7 +11,7 @@ use fvm_shared4::commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED};
 use fvm_shared4::crypto::signature::Signature;
 use fvm_shared4::econ::TokenAmount;
 use fvm_shared4::piece::PaddedPieceSize;
-use libipld_core::ipld::Ipld;
+use ipld_core::ipld::Ipld;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::{TryFrom, TryInto};
 

--- a/actors/market/src/v13/deal.rs
+++ b/actors/market/src/v13/deal.rs
@@ -11,7 +11,7 @@ use fvm_shared4::crypto::signature::Signature;
 use fvm_shared4::econ::TokenAmount;
 use fvm_shared4::piece::PaddedPieceSize;
 use fvm_shared4::sector::SectorNumber;
-use libipld_core::ipld::Ipld;
+use ipld_core::ipld::Ipld;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::{TryFrom, TryInto};
 

--- a/actors/market/src/v14/deal.rs
+++ b/actors/market/src/v14/deal.rs
@@ -11,7 +11,7 @@ use fvm_shared4::crypto::signature::Signature;
 use fvm_shared4::econ::TokenAmount;
 use fvm_shared4::piece::PaddedPieceSize;
 use fvm_shared4::sector::SectorNumber;
-use libipld_core::ipld::Ipld;
+use ipld_core::ipld::Ipld;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::{TryFrom, TryInto};
 

--- a/actors/market/src/v15/deal.rs
+++ b/actors/market/src/v15/deal.rs
@@ -11,7 +11,7 @@ use fvm_shared4::crypto::signature::Signature;
 use fvm_shared4::econ::TokenAmount;
 use fvm_shared4::piece::PaddedPieceSize;
 use fvm_shared4::sector::SectorNumber;
-use libipld_core::ipld::Ipld;
+use ipld_core::ipld::Ipld;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::{TryFrom, TryInto};
 

--- a/actors/market/src/v8/deal.rs
+++ b/actors/market/src/v8/deal.rs
@@ -1,7 +1,6 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use cid::multihash::MultihashDigest;
 use cid::Cid;
 use fil_actors_shared::v8::DealWeight;
 use fvm_ipld_encoding::tuple::*;
@@ -11,7 +10,8 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PaddedPieceSize;
-use libipld_core::ipld::Ipld;
+use ipld_core::ipld::Ipld;
+use multihash_codetable::{Code, MultihashDigest};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::{TryFrom, TryInto};
 
@@ -128,7 +128,7 @@ impl DealProposal {
         let bytes = fvm_ipld_encoding::to_vec(self)?;
         Ok(Cid::new_v1(
             fvm_ipld_encoding::DAG_CBOR,
-            cid::multihash::Code::Blake2b256.digest(&bytes),
+            Code::Blake2b256.digest(&bytes),
         ))
     }
 }
@@ -153,8 +153,8 @@ pub struct DealState {
 #[cfg(feature = "arb")]
 impl quickcheck::Arbitrary for DealProposal {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        use cid::multihash::Code::Blake2b256;
         use fvm_ipld_encoding::DAG_CBOR;
+        use multihash_codetable::Code::Blake2b256;
 
         Self {
             piece_cid: Cid::new_v1(DAG_CBOR, Blake2b256.digest(String::arbitrary(g).as_bytes())),

--- a/actors/market/src/v9/deal.rs
+++ b/actors/market/src/v9/deal.rs
@@ -10,7 +10,7 @@ use fvm_shared::clock::ChainEpoch;
 use fvm_shared::crypto::signature::Signature;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::piece::PaddedPieceSize;
-use libipld_core::ipld::Ipld;
+use ipld_core::ipld::Ipld;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::{TryFrom, TryInto};
 

--- a/actors/miner/Cargo.toml
+++ b/actors/miner/Cargo.toml
@@ -31,7 +31,7 @@ fvm_shared3 = { workspace = true }
 fvm_shared4 = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
-multihash = { workspace = true }
+multihash-codetable = { workspace = true }
 num-bigint = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }

--- a/actors/miner/src/v10/commd.rs
+++ b/actors/miner/src/v10/commd.rs
@@ -1,12 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use cid::multihash::Multihash;
 use cid::{Cid, Version};
 use fil_actors_shared::actor_error_v10;
 use fil_actors_shared::v10::ActorError;
 use fvm_shared3::commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED};
 use fvm_shared3::sector::RegisteredSealProof;
-use multihash::Multihash;
 use serde::{Deserialize, Serialize};
 
 /// `CompactCommD` represents a Cid with compact representation of context dependent zero value

--- a/actors/miner/src/v10/deadline_state.rs
+++ b/actors/miner/src/v10/deadline_state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::collections::BTreeSet;
 
 use anyhow::anyhow;
-use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_shared::actor_error_v10;
 use fil_actors_shared::v10::runtime::Policy;
@@ -18,6 +17,7 @@ use fvm_shared3::clock::{ChainEpoch, QuantSpec};
 use fvm_shared3::econ::TokenAmount;
 use fvm_shared3::error::ExitCode;
 use fvm_shared3::sector::{PoStProof, SectorSize};
+use multihash_codetable::Code;
 use num_traits::{Signed, Zero};
 
 use super::SECTORS_AMT_BITWIDTH;

--- a/actors/miner/src/v10/state.rs
+++ b/actors/miner/src/v10/state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::ops::Neg;
 
 use anyhow::{anyhow, Error};
-use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_shared::actor_error_v10;
 use fil_actors_shared::v10::runtime::Policy;
@@ -25,6 +24,7 @@ use fvm_shared3::error::ExitCode;
 use fvm_shared3::sector::{RegisteredPoStProof, SectorNumber, SectorSize, MAX_SECTOR_NUMBER};
 use fvm_shared3::{ActorID, HAMT_BIT_WIDTH};
 use itertools::Itertools;
+use multihash_codetable::Code;
 use num_traits::Zero;
 
 use super::beneficiary::*;

--- a/actors/miner/src/v11/commd.rs
+++ b/actors/miner/src/v11/commd.rs
@@ -1,12 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use cid::multihash::Multihash;
 use cid::{Cid, Version};
 use fil_actors_shared::actor_error_v11;
 use fil_actors_shared::v11::ActorError;
 use fvm_shared3::commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED};
 use fvm_shared3::sector::RegisteredSealProof;
-use multihash::Multihash;
 use serde::{Deserialize, Serialize};
 
 /// CompactCommD represents a Cid with compact representation of context dependant zero value

--- a/actors/miner/src/v11/deadline_state.rs
+++ b/actors/miner/src/v11/deadline_state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::collections::BTreeSet;
 
 use anyhow::anyhow;
-use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_shared::actor_error_v11;
 use fil_actors_shared::v11::runtime::Policy;
@@ -18,6 +17,7 @@ use fvm_shared3::clock::{ChainEpoch, QuantSpec};
 use fvm_shared3::econ::TokenAmount;
 use fvm_shared3::error::ExitCode;
 use fvm_shared3::sector::{PoStProof, SectorSize};
+use multihash_codetable::Code;
 use num_traits::{Signed, Zero};
 
 use super::SECTORS_AMT_BITWIDTH;

--- a/actors/miner/src/v11/state.rs
+++ b/actors/miner/src/v11/state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::ops::Neg;
 
 use anyhow::{anyhow, Error};
-use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_shared::actor_error_v11;
 use fil_actors_shared::v11::runtime::Policy;
@@ -19,6 +18,7 @@ use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{strict_bytes, BytesDe, CborStore};
 use fvm_ipld_hamt::Error as HamtError;
 use fvm_shared3::address::Address;
+use multihash_codetable::Code;
 
 use fvm_shared3::clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED};
 use fvm_shared3::econ::TokenAmount;

--- a/actors/miner/src/v12/deadline_state.rs
+++ b/actors/miner/src/v12/deadline_state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::collections::BTreeSet;
 
 use anyhow::anyhow;
-use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_shared::actor_error_v12;
 use fil_actors_shared::v12::runtime::Policy;
@@ -18,6 +17,7 @@ use fvm_shared4::clock::{ChainEpoch, QuantSpec};
 use fvm_shared4::econ::TokenAmount;
 use fvm_shared4::error::ExitCode;
 use fvm_shared4::sector::{PoStProof, SectorSize};
+use multihash_codetable::Code;
 use num_traits::{Signed, Zero};
 
 use super::{

--- a/actors/miner/src/v12/state.rs
+++ b/actors/miner/src/v12/state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::ops::Neg;
 
 use anyhow::{anyhow, Error};
-use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_shared::actor_error_v12;
 use fil_actors_shared::v12::runtime::Policy;
@@ -19,6 +18,7 @@ use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{strict_bytes, BytesDe, CborStore};
 use fvm_ipld_hamt::Error as HamtError;
 use fvm_shared4::address::Address;
+use multihash_codetable::Code;
 
 use fvm_shared4::clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED};
 use fvm_shared4::econ::TokenAmount;

--- a/actors/miner/src/v13/deadline_state.rs
+++ b/actors/miner/src/v13/deadline_state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::collections::BTreeSet;
 
 use anyhow::anyhow;
-use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_shared::actor_error_v13;
 use fil_actors_shared::v13::runtime::Policy;
@@ -18,6 +17,7 @@ use fvm_shared4::clock::{ChainEpoch, QuantSpec};
 use fvm_shared4::econ::TokenAmount;
 use fvm_shared4::error::ExitCode;
 use fvm_shared4::sector::{PoStProof, SectorSize};
+use multihash_codetable::Code;
 use num_traits::{Signed, Zero};
 
 use super::{

--- a/actors/miner/src/v13/state.rs
+++ b/actors/miner/src/v13/state.rs
@@ -6,7 +6,6 @@ use std::cmp;
 use std::ops::Neg;
 
 use anyhow::{anyhow, Error};
-use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_shared::actor_error_v13;
 use fil_actors_shared::v13::runtime::Policy;
@@ -21,6 +20,7 @@ use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{strict_bytes, BytesDe, CborStore};
 use fvm_ipld_hamt::Error as HamtError;
 use fvm_shared4::address::Address;
+use multihash_codetable::Code;
 
 use fvm_shared4::clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED};
 use fvm_shared4::econ::TokenAmount;

--- a/actors/miner/src/v14/deadline_state.rs
+++ b/actors/miner/src/v14/deadline_state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::collections::BTreeSet;
 
 use anyhow::anyhow;
-use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
@@ -15,6 +14,7 @@ use fvm_shared4::clock::ChainEpoch;
 use fvm_shared4::econ::TokenAmount;
 use fvm_shared4::error::ExitCode;
 use fvm_shared4::sector::{PoStProof, SectorSize};
+use multihash_codetable::Code;
 use num_traits::{Signed, Zero};
 
 use fil_actors_shared::actor_error_v14;

--- a/actors/miner/src/v14/state.rs
+++ b/actors/miner/src/v14/state.rs
@@ -6,7 +6,6 @@ use std::cmp;
 use std::ops::Neg;
 
 use anyhow::{anyhow, Error};
-use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_amt::Error as AmtError;
 use fvm_ipld_bitfield::BitField;
@@ -20,6 +19,7 @@ use fvm_shared4::error::ExitCode;
 use fvm_shared4::sector::{RegisteredPoStProof, SectorNumber, SectorSize};
 use fvm_shared4::{ActorID, HAMT_BIT_WIDTH};
 use itertools::Itertools;
+use multihash_codetable::Code;
 use num_traits::Zero;
 
 use fil_actors_shared::actor_error_v14;

--- a/actors/miner/src/v15/deadline_state.rs
+++ b/actors/miner/src/v15/deadline_state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::collections::BTreeSet;
 
 use anyhow::anyhow;
-use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_bitfield::BitField;
 use fvm_ipld_blockstore::Blockstore;
@@ -15,6 +14,7 @@ use fvm_shared4::clock::ChainEpoch;
 use fvm_shared4::econ::TokenAmount;
 use fvm_shared4::error::ExitCode;
 use fvm_shared4::sector::{PoStProof, SectorSize};
+use multihash_codetable::Code;
 use num_traits::{Signed, Zero};
 
 use fil_actors_shared::actor_error_v15;

--- a/actors/miner/src/v15/state.rs
+++ b/actors/miner/src/v15/state.rs
@@ -6,7 +6,6 @@ use std::cmp;
 use std::ops::Neg;
 
 use anyhow::{anyhow, Error};
-use cid::multihash::Code;
 use cid::Cid;
 use fvm_ipld_amt::Error as AmtError;
 use fvm_ipld_bitfield::BitField;
@@ -20,6 +19,7 @@ use fvm_shared4::error::ExitCode;
 use fvm_shared4::sector::{RegisteredPoStProof, SectorNumber, SectorSize};
 use fvm_shared4::{ActorID, HAMT_BIT_WIDTH};
 use itertools::Itertools;
+use multihash_codetable::Code;
 use num_traits::Zero;
 
 use fil_actors_shared::actor_error_v15;

--- a/actors/miner/src/v8/deadline_state.rs
+++ b/actors/miner/src/v8/deadline_state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::collections::BTreeSet;
 
 use anyhow::anyhow;
-use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_shared::actor_error_v8;
 use fil_actors_shared::v8::runtime::Policy;
@@ -18,6 +17,7 @@ use fvm_shared::clock::{ChainEpoch, QuantSpec};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::{PoStProof, SectorSize};
+use multihash_codetable::Code;
 use num_traits::{Signed, Zero};
 
 use super::SECTORS_AMT_BITWIDTH;

--- a/actors/miner/src/v8/state.rs
+++ b/actors/miner/src/v8/state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::ops::Neg;
 
 use anyhow::{anyhow, Error};
-use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_shared::actor_error_v8;
 use fil_actors_shared::v8::runtime::Policy;
@@ -24,6 +23,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::{RegisteredPoStProof, SectorNumber, SectorSize, MAX_SECTOR_NUMBER};
 use fvm_shared::HAMT_BIT_WIDTH;
+use multihash_codetable::Code;
 use num_traits::Zero;
 
 use super::deadlines::new_deadline_info;

--- a/actors/miner/src/v9/commd.rs
+++ b/actors/miner/src/v9/commd.rs
@@ -1,12 +1,12 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
+use cid::multihash::Multihash;
 use cid::{Cid, Version};
 use fil_actors_shared::actor_error_v9;
 use fil_actors_shared::v9::ActorError;
 use fvm_shared::commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED};
 use fvm_shared::sector::RegisteredSealProof;
-use multihash::Multihash;
 use serde::{Deserialize, Serialize};
 
 /// `CompactCommD` represents a Cid with compact representation of context dependent zero value

--- a/actors/miner/src/v9/deadline_state.rs
+++ b/actors/miner/src/v9/deadline_state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::collections::BTreeSet;
 
 use anyhow::anyhow;
-use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_shared::actor_error_v9;
 use fil_actors_shared::v9::runtime::Policy;
@@ -18,6 +17,7 @@ use fvm_shared::clock::{ChainEpoch, QuantSpec};
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::error::ExitCode;
 use fvm_shared::sector::{PoStProof, SectorSize};
+use multihash_codetable::Code;
 use num_traits::{Signed, Zero};
 
 use super::SECTORS_AMT_BITWIDTH;

--- a/actors/miner/src/v9/state.rs
+++ b/actors/miner/src/v9/state.rs
@@ -5,7 +5,6 @@ use std::cmp;
 use std::ops::Neg;
 
 use anyhow::{anyhow, Error};
-use cid::multihash::Code;
 use cid::Cid;
 use fil_actors_shared::actor_error_v9;
 use fil_actors_shared::v9::runtime::Policy;
@@ -19,6 +18,7 @@ use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{serde_bytes, BytesDe, CborStore};
 use fvm_ipld_hamt::Error as HamtError;
 use fvm_shared::address::Address;
+use multihash_codetable::Code;
 
 use fvm_shared::clock::{ChainEpoch, QuantSpec, EPOCH_UNDEFINED};
 use fvm_shared::econ::TokenAmount;

--- a/actors/system/Cargo.toml
+++ b/actors/system/Cargo.toml
@@ -20,6 +20,7 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_shared4 = { workspace = true }
+multihash-codetable = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }

--- a/actors/system/src/v13/mod.rs
+++ b/actors/system/src/v13/mod.rs
@@ -1,12 +1,13 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
-use cid::{multihash, Cid};
+use cid::Cid;
 use fil_actors_shared::v13::{ActorError, AsActorError};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::CborStore;
 use fvm_shared4::error::ExitCode;
 use fvm_shared4::METHOD_CONSTRUCTOR;
+use multihash_codetable::Code;
 use num_derive::FromPrimitive;
 
 /// System actor methods.
@@ -26,7 +27,7 @@ pub struct State {
 impl State {
     pub fn new<BS: Blockstore>(store: &BS) -> Result<Self, ActorError> {
         let c = store
-            .put_cbor(&Vec::<(String, Cid)>::new(), multihash::Code::Blake2b256)
+            .put_cbor(&Vec::<(String, Cid)>::new(), Code::Blake2b256)
             .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to store system state")?;
         Ok(Self { builtin_actors: c })
     }

--- a/actors/system/src/v14/mod.rs
+++ b/actors/system/src/v14/mod.rs
@@ -1,12 +1,13 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
-use cid::{multihash, Cid};
+use cid::Cid;
 use fil_actors_shared::v14::{ActorError, AsActorError};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::CborStore;
 use fvm_shared4::error::ExitCode;
 use fvm_shared4::METHOD_CONSTRUCTOR;
+use multihash_codetable::Code;
 use num_derive::FromPrimitive;
 
 /// System actor methods.
@@ -26,7 +27,7 @@ pub struct State {
 impl State {
     pub fn new<BS: Blockstore>(store: &BS) -> Result<Self, ActorError> {
         let c = store
-            .put_cbor(&Vec::<(String, Cid)>::new(), multihash::Code::Blake2b256)
+            .put_cbor(&Vec::<(String, Cid)>::new(), Code::Blake2b256)
             .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to store system state")?;
         Ok(Self { builtin_actors: c })
     }

--- a/actors/system/src/v15/mod.rs
+++ b/actors/system/src/v15/mod.rs
@@ -1,13 +1,14 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-use cid::{multihash, Cid};
+use cid::Cid;
 use fil_actors_shared::v15::{ActorError, AsActorError};
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::CborStore;
 use fvm_shared4::error::ExitCode;
 use fvm_shared4::METHOD_CONSTRUCTOR;
+use multihash_codetable::Code;
 use num_derive::FromPrimitive;
 
 /// System actor methods.
@@ -27,7 +28,7 @@ pub struct State {
 impl State {
     pub fn new<BS: Blockstore>(store: &BS) -> Result<Self, ActorError> {
         let c = store
-            .put_cbor(&Vec::<(String, Cid)>::new(), multihash::Code::Blake2b256)
+            .put_cbor(&Vec::<(String, Cid)>::new(), Code::Blake2b256)
             .context_code(ExitCode::USR_ILLEGAL_STATE, "failed to store system state")?;
         Ok(Self { builtin_actors: c })
     }

--- a/fil_actor_interface/Cargo.toml
+++ b/fil_actor_interface/Cargo.toml
@@ -32,6 +32,5 @@ fvm_shared = { workspace = true }
 fvm_shared3 = { workspace = true }
 fvm_shared4 = { workspace = true }
 integer-encoding.workspace = true
-multihash = { workspace = true, features = ["identity"] }
 num.workspace = true
 serde.workspace = true

--- a/fil_actors_shared/Cargo.toml
+++ b/fil_actors_shared/Cargo.toml
@@ -24,7 +24,7 @@ fvm_shared4 = { workspace = true }
 integer-encoding = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
-multihash = { workspace = true }
+multihash-codetable = { workspace = true }
 num = { workspace = true }
 num-bigint = { workspace = true }
 num-derive = { workspace = true }

--- a/fil_actors_shared/src/abi/commp.rs
+++ b/fil_actors_shared/src/abi/commp.rs
@@ -39,12 +39,13 @@ mod tests {
 
     use super::*;
     use anyhow::*;
+    use cid::multihash::Multihash;
     use fil_actors_test_utils::go_compat::{ensure_go_mod_prepared, go_compat_tests_dir};
     use fvm_shared::commcid::{FIL_COMMITMENT_UNSEALED, SHA2_256_TRUNC254_PADDED};
     use fvm_shared::piece::{
         zero_piece_commitment as zero_piece_commitment_v2, PaddedPieceSize as PaddedPieceSizeV2,
     };
-    use multihash::{Code::Sha2_256, Multihash, MultihashDigest};
+    use multihash_codetable::{Code, MultihashDigest};
     use quickcheck::Arbitrary;
     use quickcheck_macros::quickcheck;
 
@@ -79,7 +80,7 @@ mod tests {
             let mut pieces = Vec::with_capacity(cap);
             for _ in 0..cap {
                 let cid = {
-                    let hash = Sha2_256.digest(String::arbitrary(g).as_bytes());
+                    let hash = Code::Sha2_256.digest(String::arbitrary(g).as_bytes());
                     let mh = Multihash::wrap(SHA2_256_TRUNC254_PADDED, hash.digest()).unwrap();
                     Cid::new_v1(FIL_COMMITMENT_UNSEALED, mh)
                 };

--- a/fil_actors_shared/src/lib.rs
+++ b/fil_actors_shared/src/lib.rs
@@ -12,6 +12,7 @@ pub mod v8;
 pub mod v9;
 
 // Re-exports
+pub extern crate cid;
 pub extern crate filecoin_proofs_api;
 pub extern crate frc46_token;
 pub extern crate fvm_ipld_amt;
@@ -22,6 +23,7 @@ pub extern crate fvm_ipld_hamt;
 pub extern crate fvm_shared as fvm_shared2;
 pub extern crate fvm_shared3;
 pub extern crate fvm_shared4;
+pub extern crate multihash_codetable;
 
 pub mod ext {
     use frc46_token::token::state::{actor_id_key, StateError, TokenState};

--- a/fil_actors_shared/src/v10/runtime/empty.rs
+++ b/fil_actors_shared/src/v10/runtime/empty.rs
@@ -31,8 +31,8 @@ pub const EMPTY_ARR_CID: Cid = Cid::new_v1(
 
 #[test]
 fn test_empty_arr_cid() {
-    use cid::multihash::{Code, MultihashDigest};
     use fvm_ipld_encoding::to_vec;
+    use multihash_codetable::{Code, MultihashDigest};
 
     let empty = to_vec::<[(); 0]>(&[]).unwrap();
     let expected = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));

--- a/fil_actors_shared/src/v11/runtime/empty.rs
+++ b/fil_actors_shared/src/v11/runtime/empty.rs
@@ -31,8 +31,8 @@ pub const EMPTY_ARR_CID: Cid = Cid::new_v1(
 
 #[test]
 fn test_empty_arr_cid() {
-    use cid::multihash::{Code, MultihashDigest};
     use fvm_ipld_encoding::to_vec;
+    use multihash_codetable::{Code, MultihashDigest};
 
     let empty = to_vec::<[(); 0]>(&[]).unwrap();
     let expected = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));

--- a/fil_actors_shared/src/v12/runtime/empty.rs
+++ b/fil_actors_shared/src/v12/runtime/empty.rs
@@ -34,8 +34,8 @@ pub const EMPTY_ARR_CID: Cid = Cid::new_v1(
 
 #[test]
 fn test_empty_arr_cid() {
-    use cid::multihash::{Code, MultihashDigest};
     use fvm_ipld_encoding::to_vec;
+    use multihash_codetable::{Code, MultihashDigest};
 
     let empty = to_vec::<[(); 0]>(&[]).unwrap();
     let expected = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));

--- a/fil_actors_shared/src/v13/runtime/empty.rs
+++ b/fil_actors_shared/src/v13/runtime/empty.rs
@@ -31,8 +31,8 @@ pub const EMPTY_ARR_CID: Cid = Cid::new_v1(
 
 #[test]
 fn test_empty_arr_cid() {
-    use cid::multihash::{Code, MultihashDigest};
     use fvm_ipld_encoding::to_vec;
+    use multihash_codetable::{Code, MultihashDigest};
 
     let empty = to_vec::<[(); 0]>(&[]).unwrap();
     let expected = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));

--- a/fil_actors_shared/src/v14/runtime/empty.rs
+++ b/fil_actors_shared/src/v14/runtime/empty.rs
@@ -31,8 +31,8 @@ pub const EMPTY_ARR_CID: Cid = Cid::new_v1(
 
 #[test]
 fn test_empty_arr_cid() {
-    use cid::multihash::{Code, MultihashDigest};
     use fvm_ipld_encoding::to_vec;
+    use multihash_codetable::{Code, MultihashDigest};
 
     let empty = to_vec::<[(); 0]>(&[]).unwrap();
     let expected = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));

--- a/fil_actors_shared/src/v14/runtime/mod.rs
+++ b/fil_actors_shared/src/v14/runtime/mod.rs
@@ -26,12 +26,12 @@ mod randomness;
 pub(crate) mod empty;
 
 pub use crate::v14::vm_api::Primitives;
-use cid::multihash::Code;
 pub use empty::EMPTY_ARR_CID;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared4::chainid::ChainID;
 use fvm_shared4::event::ActorEvent;
 use fvm_shared4::sys::SendFlags;
+use multihash_codetable::Code;
 
 /// Runtime is the VM's internal runtime object.
 /// this is everything that is accessible to actors, beyond parameters.
@@ -119,7 +119,7 @@ pub trait Runtime: Primitives + RuntimePolicy {
                 actor_error_v14!(illegal_state; "failed to create state; expected empty array CID, got: {}", root),
             );
         }
-        let new_root = self.store().put_cbor(obj, Code::Blake2b256)
+        let new_root = self.store().put_cbor(obj,  Code::Blake2b256)
             .map_err(|e| actor_error_v14!(illegal_argument; "failed to write actor state during creation: {}", e.to_string()))?;
         self.set_state_root(&new_root)?;
         Ok(())

--- a/fil_actors_shared/src/v15/runtime/empty.rs
+++ b/fil_actors_shared/src/v15/runtime/empty.rs
@@ -31,8 +31,8 @@ pub const EMPTY_ARR_CID: Cid = Cid::new_v1(
 
 #[test]
 fn test_empty_arr_cid() {
-    use cid::multihash::{Code, MultihashDigest};
     use fvm_ipld_encoding::to_vec;
+    use multihash_codetable::{Code, MultihashDigest};
 
     let empty = to_vec::<[(); 0]>(&[]).unwrap();
     let expected = Cid::new_v1(DAG_CBOR, Code::Blake2b256.digest(&empty));

--- a/fil_actors_shared/src/v15/runtime/mod.rs
+++ b/fil_actors_shared/src/v15/runtime/mod.rs
@@ -26,12 +26,12 @@ mod randomness;
 pub(crate) mod empty;
 
 pub use crate::v15::vm_api::Primitives;
-use cid::multihash::Code;
 pub use empty::EMPTY_ARR_CID;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
 use fvm_shared4::chainid::ChainID;
 use fvm_shared4::event::ActorEvent;
 use fvm_shared4::sys::SendFlags;
+use multihash_codetable::Code;
 
 /// Runtime is the VM's internal runtime object.
 /// this is everything that is accessible to actors, beyond parameters.


### PR DESCRIPTION
**Summary of changes**

Part of https://github.com/ChainSafe/forest/issues/5014

Changes introduced in this pull request:

- upgrade `fvm_shared`
- upgrade `cid`, `multihash`
- upgrade `uint`
- replace `libipld` with `ipld-core`

Corresponding Forest changes are made in https://github.com/ChainSafe/forest/pull/5015
(CI tests pass. Failures in `cargo deny` and `cargo publish` are expected due to referencing unpublished crates in this repo)

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->