### PR TITLE
Revert to forest main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "forest"]
 	path = forest
 	url = https://github.com/ChainSafe/forest.git
-	branch = "shashank/use-v21-actors"
+	branch = "main"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Now we have [v21 actors](https://github.com/ChainSafe/forest/pull/5423) merged in forest main we can revert to `main` branch



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Part of https://github.com/ChainSafe/forest/issues/5136 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->