### PR TITLE
chore(ci): bump sccache-action to unblock crate publish

### DIFF
--- a/.github/composite-actions/publish-crate/action.yml
+++ b/.github/composite-actions/publish-crate/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.5
+      uses: mozilla-actions/sccache-action@v0.0.8
       continue-on-error: true
     - name: Publish crate
       run: cargo publish --package ${{ inputs.crate }} --token ${{ env.CRATES_IO_TOKEN }}


### PR DESCRIPTION
**Summary of changes**

https://github.com/ChainSafe/fil-actor-states/actions/runs/14489907727/job/40643758727#step:3:60
> sccache: error: Server startup failed: cache storage failed to read: Unexpected (permanent) at read => {"$id":"1","innerException":null,"message":"This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset","typeName":"Microsoft.Azure.DevOps.ArtifactCache.WebApi.ArtifactCacheServiceDecommissionedException, Microsoft.Azure.DevOps.ArtifactCache.WebApi","typeKey":"ArtifactCacheServiceDecommissionedException","errorCode":0,"eventId":3000}



Changes introduced in this pull request:
- 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->