### PR TITLE
Add missing `InternalSectorSetupForPresealParams` type in miner actor v14

### DIFF
--- a/actors/miner/src/v14/types.rs
+++ b/actors/miner/src/v14/types.rs
@@ -89,6 +89,15 @@ pub struct ChangeMultiaddrsParams {
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct InternalSectorSetupForPresealParams {
+    pub sectors: Vec<SectorNumber>,
+    pub reward_smoothed: FilterEstimate,
+    #[serde(with = "bigint_ser")]
+    pub reward_baseline_power: StoragePower,
+    pub quality_adj_power_smoothed: FilterEstimate,
+}
+
+#[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ConfirmSectorProofsParams {
     pub sectors: Vec<SectorNumber>,
     pub reward_smoothed: FilterEstimate,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Adds the `InternalSectorSetupForPresealParams` in miner v14 `types.rs`