### PR TITLE
Replace init actor v10 `ExecExported` method with Exec4

### DIFF
--- a/actors/init/Cargo.toml
+++ b/actors/init/Cargo.toml
@@ -12,7 +12,6 @@ keywords.workspace = true
 anyhow = { workspace = true }
 cid = { workspace = true }
 fil_actors_shared = { workspace = true }
-frc42_macros = { workspace = true }
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_ipld_hamt = { workspace = true }

--- a/actors/init/src/v10/mod.rs
+++ b/actors/init/src/v10/mod.rs
@@ -16,6 +16,5 @@ mod types;
 pub enum Method {
     Constructor = METHOD_CONSTRUCTOR,
     Exec = 2,
-    // Method numbers derived from FRC-0042 standards
-    ExecExported = frc42_macros::method_hash!("Exec"),
+    Exec4 = 3,
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Replace the `ExecExported` with the `Exec4` for the `init` actor in compliance with the builtin-actor [v10](https://github.com/filecoin-project/builtin-actors/blob/f78bf08a1f444544c22a5dea4d329b88705b0c04/actors/init/src/lib.rs#L33) and go-state-type [v10](https://github.com/filecoin-project/go-state-types/blob/f0f90965d298d86739473f13196d6ff5bcdc2d47/builtin/v10/init/methods.go#L12)