### PR TITLE
Skip actor version check when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
       - v*
 
 env:
+  SKIP_ACTOR_VERSION_CHECK: "1"
   RUSTC_WRAPPER: "sccache"
   SCCACHE_GHA_ENABLED: "true"
   CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/fil_actors_shared/build.rs
+++ b/fil_actors_shared/build.rs
@@ -8,6 +8,11 @@ use std::{env, fs};
 use walkdir::WalkDir;
 
 fn main() {
+    if env::var("SKIP_ACTOR_VERSION_CHECK").is_ok() {
+        println!("cargo:warning=Skipping actor version validation during publish.");
+        return;
+    }
+
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 
     let actors_dir = manifest_dir.join("../actors");


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow to include a global environment variable, enabling conditional skipping of actor version validation without altering triggers or steps.
  * Build process now bypasses actor version validation when the variable is set, emitting a warning and continuing.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->