### PR TITLE
update sector status code to use correct values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "26.0.0"
+version = "26.1.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ChainSafe/fil-actor-states"
 authors = [
@@ -80,18 +80,18 @@ toml = "1.0"
 uint = { version = "0.10", default-features = false }
 unsigned-varint = "0.8"
 
-fil_actor_account_state = { version = "26.0.0", path = "./actors/account" }
-fil_actor_cron_state = { version = "26.0.0", path = "./actors/cron" }
-fil_actor_datacap_state = { version = "26.0.0", path = "./actors/datacap" }
-fil_actor_evm_state = { version = "26.0.0", path = "./actors/evm" }
-fil_actor_init_state = { version = "26.0.0", path = "./actors/init" }
-fil_actor_market_state = { version = "26.0.0", path = "./actors/market" }
-fil_actor_miner_state = { version = "26.0.0", path = "./actors/miner" }
-fil_actor_multisig_state = { version = "26.0.0", path = "./actors/multisig" }
-fil_actor_power_state = { version = "26.0.0", path = "./actors/power" }
-fil_actor_reward_state = { version = "26.0.0", path = "./actors/reward" }
-fil_actor_system_state = { version = "26.0.0", path = "./actors/system" }
-fil_actor_verifreg_state = { version = "26.0.0", path = "./actors/verifreg" }
-fil_actors_shared = { version = "26.0.0", path = "./fil_actors_shared" }
+fil_actor_account_state = { version = "26.1.0", path = "./actors/account" }
+fil_actor_cron_state = { version = "26.1.0", path = "./actors/cron" }
+fil_actor_datacap_state = { version = "26.1.0", path = "./actors/datacap" }
+fil_actor_evm_state = { version = "26.1.0", path = "./actors/evm" }
+fil_actor_init_state = { version = "26.1.0", path = "./actors/init" }
+fil_actor_market_state = { version = "26.1.0", path = "./actors/market" }
+fil_actor_miner_state = { version = "26.1.0", path = "./actors/miner" }
+fil_actor_multisig_state = { version = "26.1.0", path = "./actors/multisig" }
+fil_actor_power_state = { version = "26.1.0", path = "./actors/power" }
+fil_actor_reward_state = { version = "26.1.0", path = "./actors/reward" }
+fil_actor_system_state = { version = "26.1.0", path = "./actors/system" }
+fil_actor_verifreg_state = { version = "26.1.0", path = "./actors/verifreg" }
+fil_actors_shared = { version = "26.1.0", path = "./fil_actors_shared" }
 
 fil_actors_test_utils = { path = "./fil_actors_test_utils" }

--- a/actors/miner/src/v18/types.rs
+++ b/actors/miner/src/v18/types.rs
@@ -681,13 +681,14 @@ pub struct ValidateSectorStatusReturn {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
 pub enum SectorStatusCode {
-    /// Sector is active (not terminated, not faulty)
-    Active,
     /// Sector is not live (terminated or never committed)
-    Dead,
+    Dead = 0,
+    /// Sector is active (not terminated, not faulty)
+    Active = 1,
     /// Sector is currently faulty
-    Faulty,
+    Faulty = 2,
 }
 
 pub const NO_DEADLINE: i64 = -1;

--- a/fil_actors_test_utils/Cargo.toml
+++ b/fil_actors_test_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actors_test_utils"
 description = "Test utils for fil actors"
-version = "25.0.0"
+version = "26.1.0"
 license = "MIT OR Apache-2.0"
 authors = [
   "ChainSafe Systems <info@chainsafe.io>",


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fix the `SectorStatusCode` values



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Part of https://github.com/ChainSafe/forest/issues/6920


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Sector status encoding now uses explicit byte values (Dead=0, Active=1, Faulty=2), affecting serialized representation and potential compatibility with prior versions.
* **Chores**
  * Workspace and test utilities version numbers bumped to 26.1.0.
  * Repository now tracks an updated commit for the forest submodule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->