### PR TITLE
chore: upgrade toolchain

### DIFF
--- a/actors/miner/src/v10/state.rs
+++ b/actors/miner/src/v10/state.rs
@@ -1068,7 +1068,7 @@ impl State {
             super::BitFieldQueue::new(store, &self.pre_committed_sectors_cleanup, quant)
                 .map_err(|e| e.downcast_wrap("failed to load pre-commit clean up queue"))?;
 
-        queue.add_many_to_queue_values(cleanup_events.into_iter())?;
+        queue.add_many_to_queue_values(cleanup_events)?;
         self.pre_committed_sectors_cleanup = queue.amt.flush()?;
         Ok(())
     }

--- a/actors/miner/src/v11/state.rs
+++ b/actors/miner/src/v11/state.rs
@@ -1069,7 +1069,7 @@ impl State {
             super::BitFieldQueue::new(store, &self.pre_committed_sectors_cleanup, quant)
                 .map_err(|e| e.downcast_wrap("failed to load pre-commit clean up queue"))?;
 
-        queue.add_many_to_queue_values(cleanup_events.into_iter())?;
+        queue.add_many_to_queue_values(cleanup_events)?;
         self.pre_committed_sectors_cleanup = queue.amt.flush()?;
         Ok(())
     }

--- a/actors/miner/src/v12/state.rs
+++ b/actors/miner/src/v12/state.rs
@@ -1065,7 +1065,7 @@ impl State {
             super::BitFieldQueue::new(store, &self.pre_committed_sectors_cleanup, quant)
                 .map_err(|e| e.downcast_wrap("failed to load pre-commit clean up queue"))?;
 
-        queue.add_many_to_queue_values(cleanup_events.into_iter())?;
+        queue.add_many_to_queue_values(cleanup_events)?;
         self.pre_committed_sectors_cleanup = queue.amt.flush()?;
         Ok(())
     }

--- a/actors/miner/src/v13/state.rs
+++ b/actors/miner/src/v13/state.rs
@@ -1067,7 +1067,7 @@ impl State {
             super::BitFieldQueue::new(store, &self.pre_committed_sectors_cleanup, quant)
                 .map_err(|e| e.downcast_wrap("failed to load pre-commit clean up queue"))?;
 
-        queue.add_many_to_queue_values(cleanup_events.into_iter())?;
+        queue.add_many_to_queue_values(cleanup_events)?;
         self.pre_committed_sectors_cleanup = queue.amt.flush()?;
         Ok(())
     }

--- a/actors/miner/src/v14/state.rs
+++ b/actors/miner/src/v14/state.rs
@@ -1125,7 +1125,7 @@ impl State {
             super::BitFieldQueue::new(store, &self.pre_committed_sectors_cleanup, quant)
                 .map_err(|e| e.downcast_wrap("failed to load pre-commit clean up queue"))?;
 
-        queue.add_many_to_queue_values(cleanup_events.into_iter())?;
+        queue.add_many_to_queue_values(cleanup_events)?;
         self.pre_committed_sectors_cleanup = queue.amt.flush()?;
         Ok(())
     }

--- a/actors/miner/src/v15/state.rs
+++ b/actors/miner/src/v15/state.rs
@@ -1123,7 +1123,7 @@ impl State {
             super::BitFieldQueue::new(store, &self.pre_committed_sectors_cleanup, quant)
                 .map_err(|e| e.downcast_wrap("failed to load pre-commit clean up queue"))?;
 
-        queue.add_many_to_queue_values(cleanup_events.into_iter())?;
+        queue.add_many_to_queue_values(cleanup_events)?;
         self.pre_committed_sectors_cleanup = queue.amt.flush()?;
         Ok(())
     }

--- a/actors/miner/src/v16/state.rs
+++ b/actors/miner/src/v16/state.rs
@@ -1088,7 +1088,7 @@ impl State {
             super::BitFieldQueue::new(store, &self.pre_committed_sectors_cleanup, quant)
                 .map_err(|e| e.downcast_wrap("failed to load pre-commit clean up queue"))?;
 
-        queue.add_many_to_queue_values(cleanup_events.into_iter())?;
+        queue.add_many_to_queue_values(cleanup_events)?;
         self.pre_committed_sectors_cleanup = queue.amt.flush()?;
         Ok(())
     }

--- a/actors/miner/src/v17/state.rs
+++ b/actors/miner/src/v17/state.rs
@@ -1089,7 +1089,7 @@ impl State {
             super::BitFieldQueue::new(store, &self.pre_committed_sectors_cleanup, quant)
                 .map_err(|e| e.downcast_wrap("failed to load pre-commit clean up queue"))?;
 
-        queue.add_many_to_queue_values(cleanup_events.into_iter())?;
+        queue.add_many_to_queue_values(cleanup_events)?;
         self.pre_committed_sectors_cleanup = queue.amt.flush()?;
         Ok(())
     }

--- a/actors/miner/src/v18/state.rs
+++ b/actors/miner/src/v18/state.rs
@@ -1089,7 +1089,7 @@ impl State {
             super::BitFieldQueue::new(store, &self.pre_committed_sectors_cleanup, quant)
                 .map_err(|e| e.downcast_wrap("failed to load pre-commit clean up queue"))?;
 
-        queue.add_many_to_queue_values(cleanup_events.into_iter())?;
+        queue.add_many_to_queue_values(cleanup_events)?;
         self.pre_committed_sectors_cleanup = queue.amt.flush()?;
         Ok(())
     }

--- a/actors/miner/src/v8/state.rs
+++ b/actors/miner/src/v8/state.rs
@@ -1066,7 +1066,7 @@ impl State {
             super::BitFieldQueue::new(store, &self.pre_committed_sectors_cleanup, quant)
                 .map_err(|e| e.downcast_wrap("failed to load pre-commit clean up queue"))?;
 
-        queue.add_many_to_queue_values(cleanup_events.into_iter())?;
+        queue.add_many_to_queue_values(cleanup_events)?;
         self.pre_committed_sectors_cleanup = queue.amt.flush()?;
         Ok(())
     }

--- a/actors/miner/src/v9/state.rs
+++ b/actors/miner/src/v9/state.rs
@@ -1068,7 +1068,7 @@ impl State {
             super::BitFieldQueue::new(store, &self.pre_committed_sectors_cleanup, quant)
                 .map_err(|e| e.downcast_wrap("failed to load pre-commit clean up queue"))?;
 
-        queue.add_many_to_queue_values(cleanup_events.into_iter())?;
+        queue.add_many_to_queue_values(cleanup_events)?;
         self.pre_committed_sectors_cleanup = queue.amt.flush()?;
         Ok(())
     }

--- a/fil_actors_shared/src/v13/util/batch_return.rs
+++ b/fil_actors_shared/src/v13/util/batch_return.rs
@@ -142,7 +142,7 @@ pub fn stack(batch_returns: &[BatchReturn]) -> BatchReturn {
             })
             .collect();
         base.fail_codes.extend(new_fail_codes);
-        base.fail_codes.sort_by(|a, b| a.idx.cmp(&b.idx));
+        base.fail_codes.sort_by_key(|a| a.idx);
         base.success_count = nxt.success_count;
     }
     assert_eq!(base.size(), batch_returns[0].size());

--- a/fil_actors_shared/src/v14/util/batch_return.rs
+++ b/fil_actors_shared/src/v14/util/batch_return.rs
@@ -142,7 +142,7 @@ pub fn stack(batch_returns: &[BatchReturn]) -> BatchReturn {
             })
             .collect();
         base.fail_codes.extend(new_fail_codes);
-        base.fail_codes.sort_by(|a, b| a.idx.cmp(&b.idx));
+        base.fail_codes.sort_by_key(|a| a.idx);
         base.success_count = nxt.success_count;
     }
     assert_eq!(base.size(), batch_returns[0].size());

--- a/fil_actors_shared/src/v15/util/batch_return.rs
+++ b/fil_actors_shared/src/v15/util/batch_return.rs
@@ -142,7 +142,7 @@ pub fn stack(batch_returns: &[BatchReturn]) -> BatchReturn {
             })
             .collect();
         base.fail_codes.extend(new_fail_codes);
-        base.fail_codes.sort_by(|a, b| a.idx.cmp(&b.idx));
+        base.fail_codes.sort_by_key(|a| a.idx);
         base.success_count = nxt.success_count;
     }
     assert_eq!(base.size(), batch_returns[0].size());

--- a/fil_actors_shared/src/v16/util/batch_return.rs
+++ b/fil_actors_shared/src/v16/util/batch_return.rs
@@ -142,7 +142,7 @@ pub fn stack(batch_returns: &[BatchReturn]) -> BatchReturn {
             })
             .collect();
         base.fail_codes.extend(new_fail_codes);
-        base.fail_codes.sort_by(|a, b| a.idx.cmp(&b.idx));
+        base.fail_codes.sort_by_key(|a| a.idx);
         base.success_count = nxt.success_count;
     }
     assert_eq!(base.size(), batch_returns[0].size());

--- a/fil_actors_shared/src/v17/util/batch_return.rs
+++ b/fil_actors_shared/src/v17/util/batch_return.rs
@@ -142,7 +142,7 @@ pub fn stack(batch_returns: &[BatchReturn]) -> BatchReturn {
             })
             .collect();
         base.fail_codes.extend(new_fail_codes);
-        base.fail_codes.sort_by(|a, b| a.idx.cmp(&b.idx));
+        base.fail_codes.sort_by_key(|a| a.idx);
         base.success_count = nxt.success_count;
     }
     assert_eq!(base.size(), batch_returns[0].size());

--- a/fil_actors_shared/src/v18/util/batch_return.rs
+++ b/fil_actors_shared/src/v18/util/batch_return.rs
@@ -145,7 +145,7 @@ pub fn stack(batch_returns: &[BatchReturn]) -> BatchReturn {
             })
             .collect();
         base.fail_codes.extend(new_fail_codes);
-        base.fail_codes.sort_by(|a, b| a.idx.cmp(&b.idx));
+        base.fail_codes.sort_by_key(|a| a.idx);
         base.success_count = nxt.success_count;
     }
     assert_eq!(base.size(), batch_returns[0].size());

--- a/mise.toml
+++ b/mise.toml
@@ -19,7 +19,7 @@ RUST_MIN_STACK=8388608 cargo test --workspace --all-features --all-targets
 
 [tasks.install-lint-tools]
 description = "Installs linting tools for CI"
-tools.cargo-binstall = "1.16.6"
+tools.cargo-binstall = "1.19.0"
 run = "cargo binstall --no-confirm taplo-cli cargo-spellcheck cargo-deny cargo-udeps"
 
 [tasks."lint:deny"]
@@ -115,4 +115,4 @@ description = "Clean the project."
 run = "cargo clean"
 
 [tools]
-go = "1.25.5"
+go = "1.26"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.95.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]
 targets = []


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- upgrade Rust to 1.95
- upgrade Go to 1.26
- upgrade cargo-binstall to 1.19
- fix clippy warnings
- update forest submodule to latest commit on main

Clippy warnings:
```
warning: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
    --> actors/miner/src/v10/state.rs:1071:40
     |
1071 |         queue.add_many_to_queue_values(cleanup_events.into_iter())?;
     |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
    --> actors/miner/src/v10/bitfield_queue.rs:90:22
     |
  90 |         values: impl IntoIterator<Item = (ChainEpoch, u64)>,
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#useless_conversion
     = note: `#[warn(clippy::useless_conversion)]` on by default
help: consider removing the `.into_iter()`

warning: consider using `sort_by_key`
   --> fil_actors_shared/src/v13/util/batch_return.rs:145:9
    |
145 |         base.fail_codes.sort_by(|a, b| a.idx.cmp(&b.idx));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#unnecessary_sort_by
    = note: `#[warn(clippy::unnecessary_sort_by)]` on by default
help: try
    |
145 -         base.fail_codes.sort_by(|a, b| a.idx.cmp(&b.idx));
145 +         base.fail_codes.sort_by_key(|a| a.idx);
```

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined pre-commit cleanup event processing across miner actor versions.
  * Optimized batch failure code sorting in shared utilities.

* **Chores**
  * Updated Rust toolchain to 1.95.0.
  * Updated build dependencies: cargo-binstall (1.16.6 → 1.19.0) and Go toolchain (1.25.5 → 1.26).
  * Updated forest subproject reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->